### PR TITLE
Adding oraclejdk11 in travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: java
 jdk:
+  - oraclejdk11
   - openjdk11
 
 cache:


### PR DESCRIPTION
`travis_setup_java: command not found`로 java를 설치하지 못하는 문제로 인해, 시험삼아 `oraclejdk11`도 시도해봄.