### PR TITLE
minor fix related with signup & signin

### DIFF
--- a/src/main/java/com/wafflestudio/draft/api/UserApiController.java
+++ b/src/main/java/com/wafflestudio/draft/api/UserApiController.java
@@ -53,15 +53,15 @@ public class UserApiController {
                     return null;
                 }
 
-                user = new User(signUpRequest.getUserName(), oAuth2Response.getEmail());
+                user = new User(signUpRequest.getUsername(), oAuth2Response.getEmail());
                 break;
             case "PASSWORD":
-                if (signUpRequest.getUserName() == null || signUpRequest.getEmail() == null || signUpRequest.getPassword() == null) {
+                if (signUpRequest.getUsername() == null || signUpRequest.getEmail() == null || signUpRequest.getPassword() == null) {
                     response.sendError(HttpServletResponse.SC_BAD_REQUEST);
                     return null;
                 }
 
-                user = new User(signUpRequest.getUserName(), signUpRequest.getEmail());
+                user = new User(signUpRequest.getUsername(), signUpRequest.getEmail());
                 user.setPassword(passwordEncoder.encode(signUpRequest.getPassword()));
                 break;
             default:

--- a/src/main/java/com/wafflestudio/draft/config/SecurityConfig.java
+++ b/src/main/java/com/wafflestudio/draft/config/SecurityConfig.java
@@ -94,8 +94,8 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
                 .addFilter(new JwtAuthorizationFilter(authenticationManager(), jwtTokenProvider))
                 .authorizeRequests()
                 .antMatchers(AUTH_WHITELIST_SWAGGER).permitAll()     // Swagger document
-                .antMatchers("/auth").permitAll()   // Auth entrypoint
-                .antMatchers("/api/v1/user/signup").permitAll() // SignUp user
+                .antMatchers("/api/v1/user/signin/").permitAll()   // Auth entrypoint
+                .antMatchers("/api/v1/user/signup/").permitAll() // SignUp user
                 .anyRequest().authenticated();
     }
 

--- a/src/main/java/com/wafflestudio/draft/model/request/SignUpRequest.java
+++ b/src/main/java/com/wafflestudio/draft/model/request/SignUpRequest.java
@@ -6,7 +6,7 @@ import lombok.EqualsAndHashCode;
 @EqualsAndHashCode(callSuper = true)
 @Data
 public class SignUpRequest extends AuthenticationRequest {
-    private String userName;
+    private String username;
 
     // TODO: More information about region, preference... should be added
 }


### PR DESCRIPTION
# Major changes
## 1. /api/v1/user/signup/, /api/v1/user/signin/과 대응되지 않는 SecurityConfig 수정
- `/api/v1/user/signup/`, `/api/v1/user/signin/` 과 (trailing slash까지) 정확히 대응되지 않는 `SecurityConfig`로 인해, `401 Unauthorized` 가 항상 발생하는 문제가 있었습니다. 이에 수정합니다.

## 2. /api/v1/user/signup/의 request에서 "userName"을 "username"으로 수정
- `User` class는 `username` 을 쓰고 있기에, 일관성을 위해 `username`으로 수정합니다.
- 관련 getter도 수정합니다.