### PR TITLE
Modifying Travis config & README

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,20 +1,28 @@
 language: java
-jdk:
-  - openjdk11
+
+before_cache:
+  - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock
+  - rm -fr $HOME/.gradle/caches/*/plugin-resolution/
 
 cache:
   directories:
-    - '$HOME/.gradle'
+    - $HOME/.gradle/caches/
+    - $HOME/.gradle/wrapper/
 
-dist: trusty
+os: linux
+dist: xenial
+jdk: openjdk11
 services:
   - mysql
-  - redis-server
+  - redis
 
 before-install:
   - mysql -e "CREATE DATABASE draft;"
   - mysql -e "CREATE USER 'draft-admin'@'localhost' IDENTIFIED BY 'draft-pw';"
   - mysql -e "GRANT ALL PRIVILEGES ON *.* to 'draft-admin'@'localhost';"
+
+install:
+  - ./gradlew assemble
 
 script:
   - ./gradlew clean build

--- a/README.md
+++ b/README.md
@@ -24,6 +24,10 @@ mysql -u root -e "GRANT ALL PRIVILEGES ON *.* to 'draft-admin'@'localhost';"
 ./gradlew clean build
 ```
 
+## Endpoint
+- devel: http://ec2-15-165-158-156.ap-northeast-2.compute.amazonaws.com
+- prod: not yet
+
 ### API documentation
 - http://ec2-15-165-158-156.ap-northeast-2.compute.amazonaws.com/swagger-ui.html
 - https://github.com/wafflestudio/draft-server/wiki/Api-Specification

--- a/README.md
+++ b/README.md
@@ -1,12 +1,32 @@
-# draft-server
-[![Build Status](https://travis-ci.com/wafflestudio/draft-server.svg?token=siV9jNpC1p2FuLSyqUnp&branch=master)](https://travis-ci.com/wafflestudio/draft-server)
-- How to run?
-```shell script
+# draft-server [![Build Status](https://travis-ci.com/wafflestudio/draft-server.svg?token=siV9jNpC1p2FuLSyqUnp&branch=master)](https://travis-ci.com/wafflestudio/draft-server)
+
+- How to set up?
+```
 mysql.server start
-mysql -e "CREATE DATABASE draft;"
-mysql -e "CREATE USER 'draft-admin'@'localhost' IDENTIFIED BY 'draft-pw';"
-mysql -e "GRANT ALL PRIVILEGES ON *.* to 'draft-admin'@'localhost';"
-./gradlew clean build
+mysql -u root -e "CREATE DATABASE draft;"
+mysql -u root -e "CREATE USER 'draft-admin'@'localhost' IDENTIFIED BY 'draft-pw';"
+mysql -u root -e "GRANT ALL PRIVILEGES ON *.* to 'draft-admin'@'localhost';"
+./gradlew assemble
+```
+
+- How to test?
+```
+./gradlew test
+```
+
+- How to run?
+```
 ./gradlew bootRun
 ```
 
+- How to build?
+```
+./gradlew clean build
+```
+
+### API documentation
+- http://ec2-15-165-158-156.ap-northeast-2.compute.amazonaws.com/swagger-ui.html
+- https://github.com/wafflestudio/draft-server/wiki/Api-Specification
+
+### Wiki
+- https://github.com/wafflestudio/draft-server/wiki


### PR DESCRIPTION
# Major Changes
## 1. Modifying Travis config
- 어제 경부터 `openjdk11`을 계속 사용하지 못하는 `Linux (Trusty)` 대신 `Linux (Xenial)`을 사용.(이제 내부 build log를 보면 `openjdk11`을 사용하고 있음을 확인할 수 있음.
- 그 외 cache 관련 command 등 수정

## 2. Modifying README
- command들 사소한 수정 및 세분화
- Endpoint, API documentation, Wiki 링크 추가
