### PR TITLE
Improving Room Create & Get APIs

### DIFF
--- a/src/main/java/com/wafflestudio/draft/model/Room.java
+++ b/src/main/java/com/wafflestudio/draft/model/Room.java
@@ -26,5 +26,7 @@ public class Room extends BaseTimeEntity {
 
     private LocalDateTime endTime;
 
+    private String name;
+
     // TODO: court_id
 }

--- a/src/main/java/com/wafflestudio/draft/repository/RoomRepository.java
+++ b/src/main/java/com/wafflestudio/draft/repository/RoomRepository.java
@@ -2,9 +2,11 @@ package com.wafflestudio.draft.repository;
 
 import com.wafflestudio.draft.model.Room;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import javax.persistence.EntityManager;
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Repository
@@ -22,7 +24,14 @@ public class RoomRepository {
     }
 
     public List<Room> findAll() {
-        return em.createQuery("select r from Room r", Room.class)
+        return em.createQuery("SELECT r FROM Room r", Room.class)
+                .getResultList();
+    }
+
+    public List<Room> findAll(String name, LocalDateTime startTime, LocalDateTime endTime) {
+        return em.createQuery("SELECT r FROM Room r " +
+                              "WHERE r.name LIKE concat('%', :name, '%') ", Room.class)
+                .setParameter("name", name)
                 .getResultList();
     }
 }

--- a/src/main/java/com/wafflestudio/draft/service/RoomService.java
+++ b/src/main/java/com/wafflestudio/draft/service/RoomService.java
@@ -6,6 +6,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Service
@@ -23,6 +24,10 @@ public class RoomService {
 
     public List<Room> findRooms() {
         return roomRepository.findAll();
+    }
+
+    public List<Room> findRooms(String name, LocalDateTime startTime, LocalDateTime endTime) {
+        return roomRepository.findAll(name, startTime, endTime);
     }
 
     public Room findOne(Long roomId) {


### PR DESCRIPTION
# Major Changes
## 1. Improving Room Create & Get APIs
- 일관성을 위해 Room GET API들의 response에서 `"startAt"`, `"endAt"`을 `"startTime"`,` "endTime"`으로 변경합니다.
- Room의 `name`을 추가하고, Room CREATE와 GET API들에서 관련 request, response를 변경합니다.
- Room CREATE API의 response를 Room GET API들과 일관되게 맞춥니다.
- `GET /api/v1/room/` 에서 param으로 `name`을 주면 `LIKE` query를 이용해 해당하는 Room들만 가져오도록 합니다. param이 없으면 전체 Room들을 가져옵니다.
- https://draft-waffle.atlassian.net/wiki/spaces/DRAFTWAFFL/pages/33155/Room+API 에 변경 사항 반영할 예정입니다.