### PR TITLE
Feature/#32

### DIFF
--- a/src/main/java/com/wafflestudio/draft/config/SecurityConfig.java
+++ b/src/main/java/com/wafflestudio/draft/config/SecurityConfig.java
@@ -5,6 +5,7 @@ import com.wafflestudio.draft.security.JwtAuthenticationEntryPoint;
 import com.wafflestudio.draft.security.JwtAuthorizationFilter;
 import com.wafflestudio.draft.security.JwtTokenProvider;
 import com.wafflestudio.draft.security.oauth2.OAuth2Provider;
+import com.wafflestudio.draft.security.oauth2.client.FacebookOAuth2Client;
 import com.wafflestudio.draft.security.oauth2.client.KakaoOAuth2Client;
 import com.wafflestudio.draft.security.oauth2.client.TestOAuth2Client;
 import com.wafflestudio.draft.security.password.UserPrincipalDetailService;
@@ -37,6 +38,8 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
 
     private final TestOAuth2Client testOAuth2Client;
 
+    private final FacebookOAuth2Client facebookOAuth2Client;
+
     private static final String[] AUTH_WHITELIST_SWAGGER = {
             // -- swagger ui
             "/swagger-resources/**",
@@ -45,12 +48,13 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
             "/webjars/**"
     };
 
-    public SecurityConfig(JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint, JwtTokenProvider jwtTokenProvider, UserPrincipalDetailService userPrincipalDetailService, KakaoOAuth2Client kakaoOAuth2Client, TestOAuth2Client testOAuth2Client) {
+    public SecurityConfig(JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint, JwtTokenProvider jwtTokenProvider, UserPrincipalDetailService userPrincipalDetailService, KakaoOAuth2Client kakaoOAuth2Client, TestOAuth2Client testOAuth2Client, FacebookOAuth2Client facebookOAuth2Client) {
         this.jwtAuthenticationEntryPoint = jwtAuthenticationEntryPoint;
         this.jwtTokenProvider = jwtTokenProvider;
         this.userPrincipalDetailService = userPrincipalDetailService;
         this.kakaoOAuth2Client = kakaoOAuth2Client;
         this.testOAuth2Client = testOAuth2Client;
+        this.facebookOAuth2Client = facebookOAuth2Client;
     }
 
     @Override
@@ -69,6 +73,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
     OAuth2Provider oAuth2AuthenticationProvider() {
         OAuth2Provider provider = new OAuth2Provider();
         provider.addOAuth2Client(KakaoOAuth2Client.OAUTH_TOKEN_PREFIX, kakaoOAuth2Client);
+        provider.addOAuth2Client(FacebookOAuth2Client.OAUTH_TOKEN_PREFIX, facebookOAuth2Client);
         provider.addOAuth2Client(TestOAuth2Client.OAUTH_TOKEN_PREFIX, testOAuth2Client);
         return provider;
     }

--- a/src/main/java/com/wafflestudio/draft/model/Room.java
+++ b/src/main/java/com/wafflestudio/draft/model/Room.java
@@ -26,5 +26,7 @@ public class Room extends BaseTimeEntity {
 
     private LocalDateTime endTime;
 
+    private String name;
+
     // TODO: court_id
 }

--- a/src/main/java/com/wafflestudio/draft/repository/RoomRepository.java
+++ b/src/main/java/com/wafflestudio/draft/repository/RoomRepository.java
@@ -2,9 +2,11 @@ package com.wafflestudio.draft.repository;
 
 import com.wafflestudio.draft.model.Room;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import javax.persistence.EntityManager;
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Repository
@@ -22,7 +24,14 @@ public class RoomRepository {
     }
 
     public List<Room> findAll() {
-        return em.createQuery("select r from Room r", Room.class)
+        return em.createQuery("SELECT r FROM Room r", Room.class)
+                .getResultList();
+    }
+
+    public List<Room> findAll(String name, LocalDateTime startTime, LocalDateTime endTime) {
+        return em.createQuery("SELECT r FROM Room r " +
+                              "WHERE r.name LIKE concat('%', :name, '%') ", Room.class)
+                .setParameter("name", name)
                 .getResultList();
     }
 }

--- a/src/main/java/com/wafflestudio/draft/security/oauth2/OAuth2Provider.java
+++ b/src/main/java/com/wafflestudio/draft/security/oauth2/OAuth2Provider.java
@@ -19,7 +19,7 @@ public class OAuth2Provider implements AuthenticationProvider {
     @Autowired
     private AuthUserService authUserService;
 
-    private Map<String, OAuth2Client> oAuth2ClientMap = new HashMap<>();
+    private final Map<String, OAuth2Client> oAuth2ClientMap = new HashMap<>();
 
     @Override
     public Authentication authenticate(Authentication authentication) throws AuthenticationException {

--- a/src/main/java/com/wafflestudio/draft/security/oauth2/client/FacebookOAuth2Client.java
+++ b/src/main/java/com/wafflestudio/draft/security/oauth2/client/FacebookOAuth2Client.java
@@ -1,0 +1,60 @@
+package com.wafflestudio.draft.security.oauth2.client;
+
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.*;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Component;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.util.HashMap;
+
+@Component
+public class FacebookOAuth2Client implements OAuth2Client {
+    public static final String OAUTH_TOKEN_PREFIX = "FACEBOOK";
+
+//    Request Example
+//
+//    GET /me/
+//    Host: https://graph.facebook.com/v7.0/
+//    Query: access_token={access_token}
+
+    private static final String FACEBOOK_HOST = "https://graph.facebook.com/v7.0/";
+
+    @Override
+    public OAuth2Response userInfo(String accessToken) throws AuthenticationException {
+
+        RestTemplate template = new RestTemplate();
+
+        MultiValueMap<String, String> headers = new HttpHeaders();
+        UriComponentsBuilder builder = UriComponentsBuilder.fromHttpUrl(FACEBOOK_HOST + "/me")
+                .queryParam("access_token", accessToken);
+
+
+        HttpEntity<MultiValueMap<String, String>> entity = new HttpEntity<>(headers);
+        ParameterizedTypeReference<HashMap<String, Object>> responseType =
+                new ParameterizedTypeReference<HashMap<String, Object>>() {
+                };
+
+        ResponseEntity<HashMap<String, Object>> response = template.exchange(
+                builder.toUriString(),
+                HttpMethod.GET,
+                entity,
+                responseType);
+
+        if (response.getStatusCode() != HttpStatus.OK ||
+                !response.hasBody() ||
+                !response.getBody().containsKey("name") ||
+                !(response.getBody().get("name") instanceof String)) {
+            throw new UsernameNotFoundException("Cannot retrieve user info from FACEBOOK Auth server");
+        }
+
+        String account_name = response.getBody().get("name").toString();
+
+        System.out.println(account_name);
+
+        return new OAuth2Response(OAUTH_TOKEN_PREFIX, account_name, response.getStatusCode());
+    }
+}

--- a/src/main/java/com/wafflestudio/draft/service/RoomService.java
+++ b/src/main/java/com/wafflestudio/draft/service/RoomService.java
@@ -6,6 +6,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Service
@@ -23,6 +24,10 @@ public class RoomService {
 
     public List<Room> findRooms() {
         return roomRepository.findAll();
+    }
+
+    public List<Room> findRooms(String name, LocalDateTime startTime, LocalDateTime endTime) {
+        return roomRepository.findAll(name, startTime, endTime);
     }
 
     public Room findOne(Long roomId) {


### PR DESCRIPTION
## Kakao, Facebook OAuth2 로그인을 위한 client 추가
- Kakao access token을 통한 인증 + email 발급 로직 추가
- Facebook access token을 통한 인증 로직 추가

## ⚠️ **논의 사항**
- Kakao, Facebook 모두 소셜 로그인으로 유저 이메일을 항상 확인할 수 없음
  - kakao 의 경우, 유저가 이메일 권한을 거부해도 소셜 로그인 가능함, 물론 이에 대해 다시 권한을 요청한다던지 등의 로직을 만들 수는 있음
  - facebook 의 경우, kakao와 같이 권한을 거부할 수 있고, 추가적으로 email에 대한 validation이 안됀 유저들이 존재하고 이런 유저들에 대한 이메일 정보는 제공받을 수 없음. (즉 아예 이메일 정보가 등록이 안돼있을 가능성이 존재함)
- 해결방법1
  - User 에 대한 unique identifier를 (인증방식, 해당 인증 방식에 따른 unique id) 의 튜플 형태로 고유하게 저장하는 방법
    - 예시: (KAKAO, 123456789), (FACEBOOK, 987654321), (EMAIL, johndoe@example.com)
    - 구현이 귀찮아 질 가능성 존재
- 해결방법2
  - User 의 unique identifier로 username 을 사용하기, email 등은 nullable 한 정보 나두기
    - 유저네임의 지유도가 떨어지긴 함
    - 또한 클라이언트에서 로그인을 위해 항상 username 정보를 받아와야 한다.