### PR TITLE
consider error cases for joining room

### DIFF
--- a/src/main/java/com/wafflestudio/draft/DataLoader.java
+++ b/src/main/java/com/wafflestudio/draft/DataLoader.java
@@ -15,6 +15,8 @@ import org.springframework.boot.ApplicationRunner;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Component;
 
+import java.time.LocalDateTime;
+
 @Component
 @RequiredArgsConstructor
 public class DataLoader implements ApplicationRunner {
@@ -65,6 +67,8 @@ public class DataLoader implements ApplicationRunner {
             room.setOwner(oauth2User);
             room.setCourt(testCourt);
             room.setName("TEST_ROOM_" + i);
+            room.setStartTime(LocalDateTime.now());
+            room.setEndTime(LocalDateTime.now().plusHours(1));
             roomService.save(room);
         }
     }

--- a/src/main/java/com/wafflestudio/draft/DataLoader.java
+++ b/src/main/java/com/wafflestudio/draft/DataLoader.java
@@ -8,6 +8,7 @@ import com.wafflestudio.draft.repository.CourtRepository;
 import com.wafflestudio.draft.repository.DeviceRepository;
 import com.wafflestudio.draft.repository.RegionRepository;
 import com.wafflestudio.draft.repository.UserRepository;
+import com.wafflestudio.draft.service.ParticipantService;
 import com.wafflestudio.draft.service.RoomService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.boot.ApplicationArguments;
@@ -26,6 +27,7 @@ public class DataLoader implements ApplicationRunner {
     final DeviceRepository deviceRepository;
     final GeometryFactory gf = new GeometryFactory();
     final RoomService roomService;
+    final ParticipantService participantService;
 
     @Override
     public void run(ApplicationArguments args) {
@@ -70,6 +72,7 @@ public class DataLoader implements ApplicationRunner {
             room.setStartTime(LocalDateTime.now());
             room.setEndTime(LocalDateTime.now().plusHours(1));
             roomService.save(room);
+            participantService.addParticipants(room, oauth2User);
         }
     }
 }

--- a/src/main/java/com/wafflestudio/draft/api/RegionApiController.java
+++ b/src/main/java/com/wafflestudio/draft/api/RegionApiController.java
@@ -1,8 +1,9 @@
 package com.wafflestudio.draft.api;
 
+import com.wafflestudio.draft.dto.request.GetRegionsRequest;
+import com.wafflestudio.draft.dto.response.RegionResponse;
 import com.wafflestudio.draft.model.Region;
 import com.wafflestudio.draft.service.RegionService;
-import lombok.Data;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
@@ -32,27 +33,5 @@ public class RegionApiController {
             getRegionsResponse.add(new RegionResponse(region));
         }
         return getRegionsResponse;
-    }
-
-    @Data
-    static class GetRegionsRequest {
-        private String name;
-    }
-
-    @Data
-    static class RegionResponse {
-        private Long id;
-        private String name;
-        private String depth1;
-        private String depth2;
-        private String depth3;
-
-        public RegionResponse(Region region) {
-            this.id = region.getId();
-            this.name = region.getName();
-            this.depth1 = region.getDepth1();
-            this.depth2 = region.getDepth2();
-            this.depth3 = region.getDepth3();
-        }
     }
 }

--- a/src/main/java/com/wafflestudio/draft/api/RoomApiController.java
+++ b/src/main/java/com/wafflestudio/draft/api/RoomApiController.java
@@ -89,10 +89,13 @@ public class RoomApiController {
         if (room == null) {
             throw new ResponseStatusException(HttpStatus.NOT_FOUND);
         }
+        if (room.getStatus() != RoomStatus.WAITING) {
+            throw new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY);
+        }
 
         List<Participant> participants = room.getParticipants();
         for (Participant participant : participants) {
-            if (currentUser.getId() == participant.getUser().getId()) {
+            if (currentUser.getId().equals(participant.getUser().getId())) {
                 throw new ResponseStatusException(HttpStatus.BAD_REQUEST);
             }
         }

--- a/src/main/java/com/wafflestudio/draft/dto/request/GetRegionsRequest.java
+++ b/src/main/java/com/wafflestudio/draft/dto/request/GetRegionsRequest.java
@@ -1,0 +1,8 @@
+package com.wafflestudio.draft.dto.request;
+
+import lombok.Data;
+
+@Data
+public class GetRegionsRequest {
+    private String name;
+}

--- a/src/main/java/com/wafflestudio/draft/dto/response/RegionResponse.java
+++ b/src/main/java/com/wafflestudio/draft/dto/response/RegionResponse.java
@@ -1,0 +1,21 @@
+package com.wafflestudio.draft.dto.response;
+
+import com.wafflestudio.draft.model.Region;
+import lombok.Data;
+
+@Data
+public class RegionResponse {
+    private Long id;
+    private String name;
+    private String depth1;
+    private String depth2;
+    private String depth3;
+
+    public RegionResponse(Region region) {
+        this.id = region.getId();
+        this.name = region.getName();
+        this.depth1 = region.getDepth1();
+        this.depth2 = region.getDepth2();
+        this.depth3 = region.getDepth3();
+    }
+}

--- a/src/main/java/com/wafflestudio/draft/model/Participant.java
+++ b/src/main/java/com/wafflestudio/draft/model/Participant.java
@@ -9,6 +9,11 @@ import javax.persistence.*;
 @RequiredArgsConstructor
 @NoArgsConstructor
 @Entity
+@Table(
+        uniqueConstraints = @UniqueConstraint(
+                columnNames = {"user_id", "room_id"}
+        )
+)
 public class Participant extends BaseTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/wafflestudio/draft/model/Room.java
+++ b/src/main/java/com/wafflestudio/draft/model/Room.java
@@ -6,6 +6,7 @@ import lombok.Setter;
 
 import javax.persistence.*;
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Entity
 @Getter
@@ -22,6 +23,9 @@ public class Room extends BaseTimeEntity {
     @ManyToOne(optional = false, fetch = FetchType.LAZY)
     @JoinColumn(name = "owner_id", referencedColumnName = "id")
     private User owner;
+
+    @OneToMany(mappedBy = "room")
+    private List<Participant> participants;
 
     private LocalDateTime startTime;
 


### PR DESCRIPTION
related issues: #39 
related PRs: #42 

# Major Changes
## 1. POST /api/v1/room/{room_id}/participant/ 의 에러 케이스 추가
- Room의 Participant 수가 이미 Court의 capacity 이상인 경우 409 CONFLICT
- Room에 이미 자기 자신이 Participant로 존재하는 경우 400 BAD REQUEST
- 해당 Room이 WAITING 상태가 아닌 경우 422 UNPROCESSABLE_ENTITY

## 2. POST /api/v1/room/에서 Participant 관련 로직 추가
- Room을 생성하는 User가 Participant로서 자동으로 추가되도록 함
- Participant의 user_id, room_id column에 unique constraint 추가

* * *

# Minor Changes
## 1. DataLoader에서 Room의 startTime과 endTime을 설정
- 모든 Room은 startTime과 endTime이 있으므로, 정상 데이터와 같도록 설정
- 방의 owner가 Participant로서 속하도록 설정

## 2. Region 관련 Request, Response를 dto directory로 분리
