### PR TITLE
get belonging rooms API

### DIFF
--- a/src/main/java/com/wafflestudio/draft/api/UserApiController.java
+++ b/src/main/java/com/wafflestudio/draft/api/UserApiController.java
@@ -7,11 +7,9 @@ import com.wafflestudio.draft.dto.request.SetPreferenceRequest;
 import com.wafflestudio.draft.dto.request.SignUpRequest;
 import com.wafflestudio.draft.dto.response.DeviceResponse;
 import com.wafflestudio.draft.dto.response.PreferenceInRegionResponse;
+import com.wafflestudio.draft.dto.response.RoomsOfUserResponse;
 import com.wafflestudio.draft.dto.response.UserInformationResponse;
-import com.wafflestudio.draft.model.Device;
-import com.wafflestudio.draft.model.Preference;
-import com.wafflestudio.draft.model.Region;
-import com.wafflestudio.draft.model.User;
+import com.wafflestudio.draft.model.*;
 import com.wafflestudio.draft.security.CurrentUser;
 import com.wafflestudio.draft.security.oauth2.AuthUserService;
 import com.wafflestudio.draft.security.oauth2.OAuth2Provider;
@@ -20,6 +18,7 @@ import com.wafflestudio.draft.security.password.UserPrincipal;
 import com.wafflestudio.draft.service.DeviceService;
 import com.wafflestudio.draft.service.PreferenceService;
 import com.wafflestudio.draft.service.RegionService;
+import com.wafflestudio.draft.service.RoomService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -47,6 +46,7 @@ public class UserApiController {
     private final RegionService regionService;
     private final PreferenceService preferenceService;
     private final DeviceService deviceService;
+    private final RoomService roomService;
 
     @PostMapping("/signup/")
     public ResponseEntity<User> createUser(@RequestBody SignUpRequest signUpRequest, HttpServletResponse response) throws IOException {
@@ -124,5 +124,11 @@ public class UserApiController {
         device.setDeviceToken(request.getDeviceToken());
         deviceService.create(device);
         return new DeviceResponse(device);
+    }
+
+    @GetMapping("/room/")
+    public RoomsOfUserResponse getBelongingRooms(@CurrentUser User currentUser) {
+        List<Room> rooms = roomService.findRoomsByUser(currentUser);
+        return new RoomsOfUserResponse(currentUser, rooms);
     }
 }

--- a/src/main/java/com/wafflestudio/draft/dto/response/RoomsOfUserResponse.java
+++ b/src/main/java/com/wafflestudio/draft/dto/response/RoomsOfUserResponse.java
@@ -1,0 +1,27 @@
+package com.wafflestudio.draft.dto.response;
+
+import com.wafflestudio.draft.model.Room;
+import com.wafflestudio.draft.model.User;
+import lombok.Data;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Data
+public class RoomsOfUserResponse {
+    private Long id;
+    private String username;
+    private String email;
+    private List<RoomResponse> rooms;
+
+    public RoomsOfUserResponse(User user, List<Room> rooms) {
+        this.id = user.getId();
+        this.username = user.getUsername();
+        this.email = user.getEmail();
+        List<RoomResponse> roomResponses = new ArrayList<>();
+        for (Room room : rooms) {
+            roomResponses.add(new RoomResponse(room));
+        }
+        this.rooms = roomResponses;
+    }
+}

--- a/src/main/java/com/wafflestudio/draft/repository/RoomRepository.java
+++ b/src/main/java/com/wafflestudio/draft/repository/RoomRepository.java
@@ -1,6 +1,7 @@
 package com.wafflestudio.draft.repository;
 
 import com.wafflestudio.draft.model.Room;
+import com.wafflestudio.draft.model.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
@@ -42,5 +43,14 @@ public class RoomRepository {
                     .setParameter("court_id", courtId)
                     .getResultList();
         }
+    }
+
+    public List<Room> findRoomsByUser(User user) {
+        return em.createQuery("SELECT r FROM Participant p " +
+                        "INNER JOIN p.room r " +
+                        "WHERE p.user = :user"
+                , Room.class)
+                .setParameter("user", user)
+                .getResultList();
     }
 }

--- a/src/main/java/com/wafflestudio/draft/service/RoomService.java
+++ b/src/main/java/com/wafflestudio/draft/service/RoomService.java
@@ -1,6 +1,7 @@
 package com.wafflestudio.draft.service;
 
 import com.wafflestudio.draft.model.Room;
+import com.wafflestudio.draft.model.User;
 import com.wafflestudio.draft.repository.RoomRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -22,11 +23,15 @@ public class RoomService {
         return room.getId();
     }
 
+    public Room findOne(Long roomId) {
+        return roomRepository.findOne(roomId);
+    }
+
     public List<Room> findRooms(String name, Long courtId, LocalDateTime startTime, LocalDateTime endTime) {
         return roomRepository.findRooms(name, courtId, startTime, endTime);
     }
 
-    public Room findOne(Long roomId) {
-        return roomRepository.findOne(roomId);
+    public List<Room> findRoomsByUser(User user) {
+        return roomRepository.findRoomsByUser(user);
     }
 }


### PR DESCRIPTION
This PR will resolve #44 issue.

# Major Changes
## 1. GET /api/v1/user/room/
- 자신이 속한 Room 정보들을 가져오는 API
- response 형태는 아래와 같습니다.
```
{
    "id": 3,
    "username": "다빈",
    "email": "bdv111@test.com",
    "rooms": [
        {
            "id": 1,
            "roomStatus": "WAITING",
            "startTime": null,
            "endTime": null,
            "name": "TEST_ROOM_1",
            "createdAt": "2020-07-25T19:47:53.469232",
            "ownerId": 1,
            "courtId": 1
        },
        ...
    ]
}
```
