### PR TITLE
check username

### DIFF
--- a/src/main/java/com/wafflestudio/draft/api/UserApiController.java
+++ b/src/main/java/com/wafflestudio/draft/api/UserApiController.java
@@ -1,10 +1,7 @@
 package com.wafflestudio.draft.api;
 
 
-import com.wafflestudio.draft.dto.request.GetUsersByPreferenceRequest;
-import com.wafflestudio.draft.dto.request.SetDeviceRequest;
-import com.wafflestudio.draft.dto.request.SetPreferenceRequest;
-import com.wafflestudio.draft.dto.request.SignUpRequest;
+import com.wafflestudio.draft.dto.request.*;
 import com.wafflestudio.draft.dto.response.DeviceResponse;
 import com.wafflestudio.draft.dto.response.PreferenceInRegionResponse;
 import com.wafflestudio.draft.dto.response.RoomsOfUserResponse;
@@ -16,10 +13,7 @@ import com.wafflestudio.draft.security.oauth2.AuthUserService;
 import com.wafflestudio.draft.security.oauth2.OAuth2Provider;
 import com.wafflestudio.draft.security.oauth2.client.OAuth2Response;
 import com.wafflestudio.draft.security.password.UserPrincipal;
-import com.wafflestudio.draft.service.DeviceService;
-import com.wafflestudio.draft.service.PreferenceService;
-import com.wafflestudio.draft.service.RegionService;
-import com.wafflestudio.draft.service.RoomService;
+import com.wafflestudio.draft.service.*;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -43,6 +37,7 @@ public class UserApiController {
 
     private final OAuth2Provider oAuth2Provider;
     private final AuthUserService authUserService;
+    private final UserService userService;
     private final PasswordEncoder passwordEncoder;
     private final RegionService regionService;
     private final PreferenceService preferenceService;
@@ -51,8 +46,13 @@ public class UserApiController {
     private final JwtTokenProvider jwtTokenProvider;
 
     @PostMapping("/signup/")
-    public ResponseEntity<User> createUser(@RequestBody SignUpRequest signUpRequest, HttpServletResponse response) throws IOException {
+    public ResponseEntity<User> createUser(@RequestBody @Valid SignUpRequest signUpRequest, HttpServletResponse response) throws IOException {
         User user;
+        String username = signUpRequest.getUsername();
+
+        if (userService.existsUserByUsername(username)) {
+            throw new ResponseStatusException(HttpStatus.CONFLICT);
+        }
 
         switch (signUpRequest.getGrantType()) {
             case "OAUTH":
@@ -62,15 +62,15 @@ public class UserApiController {
                     return null;
                 }
 
-                user = new User(signUpRequest.getUsername(), oAuth2Response.getEmail());
+                user = new User(username, oAuth2Response.getEmail());
                 break;
             case "PASSWORD":
-                if (signUpRequest.getUsername() == null || signUpRequest.getEmail() == null || signUpRequest.getPassword() == null) {
+                if (username == null || signUpRequest.getEmail() == null || signUpRequest.getPassword() == null) {
                     response.sendError(HttpServletResponse.SC_BAD_REQUEST);
                     return null;
                 }
 
-                user = new User(signUpRequest.getUsername(), signUpRequest.getEmail());
+                user = new User(username, signUpRequest.getEmail());
                 user.setPassword(passwordEncoder.encode(signUpRequest.getPassword()));
                 break;
             default:
@@ -84,6 +84,14 @@ public class UserApiController {
         return new ResponseEntity<>(user, HttpStatus.CREATED);
     }
 
+    @GetMapping("/check-username/")
+    public ResponseEntity<Void> checkUsername(@RequestBody @Valid CheckUsernameRequest checkUsernameRequest) {
+        if (userService.existsUserByUsername(checkUsernameRequest.getUsername())) {
+            throw new ResponseStatusException(HttpStatus.CONFLICT);
+        }
+        return new ResponseEntity<Void>(HttpStatus.OK);
+    }
+
     //    @PreAuthorize("hasRole('ROLE_USER')")
     @GetMapping("/me/")
     public ResponseEntity<UserInformationResponse> myInfo(@CurrentUser UserPrincipal currentUser) {
@@ -92,7 +100,7 @@ public class UserApiController {
 
     //    @PreAuthorize("hasRole('ROLE_USER')")
     @PostMapping("/info/")
-    public List<PreferenceInRegionResponse> setPreferences(@Valid @RequestBody List<SetPreferenceRequest> preferenceRequestList, @CurrentUser UserPrincipal currentUser) {
+    public List<PreferenceInRegionResponse> setPreferences(@RequestBody @Valid List<SetPreferenceRequest> preferenceRequestList, @CurrentUser UserPrincipal currentUser) {
         List<PreferenceInRegionResponse> preferenceInRegionResponses = new ArrayList<>();
 
         for (SetPreferenceRequest preferenceRequest : preferenceRequestList) {

--- a/src/main/java/com/wafflestudio/draft/config/SecurityConfig.java
+++ b/src/main/java/com/wafflestudio/draft/config/SecurityConfig.java
@@ -99,8 +99,9 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
                 .addFilter(new JwtAuthorizationFilter(authenticationManager(), jwtTokenProvider))
                 .authorizeRequests()
                 .antMatchers(AUTH_WHITELIST_SWAGGER).permitAll()     // Swagger document
-                .antMatchers("/api/v1/user/signin/").permitAll()   // Auth entrypoint
-                .antMatchers("/api/v1/user/signup/").permitAll() // SignUp user
+                .antMatchers("/api/v1/user/signin/").permitAll()  // Auth entrypoint
+                .antMatchers("/api/v1/user/signup/").permitAll()  // SignUp user
+                .antMatchers("/api/v1/user/check-username/").permitAll()
                 .anyRequest().authenticated();
     }
 

--- a/src/main/java/com/wafflestudio/draft/dto/request/CheckUsernameRequest.java
+++ b/src/main/java/com/wafflestudio/draft/dto/request/CheckUsernameRequest.java
@@ -1,0 +1,11 @@
+package com.wafflestudio.draft.dto.request;
+
+import lombok.Data;
+
+import javax.validation.constraints.NotNull;
+
+@Data
+public class CheckUsernameRequest {
+    @NotNull
+    private String username;
+}

--- a/src/main/java/com/wafflestudio/draft/dto/request/SignUpRequest.java
+++ b/src/main/java/com/wafflestudio/draft/dto/request/SignUpRequest.java
@@ -3,10 +3,20 @@ package com.wafflestudio.draft.dto.request;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 
+import javax.validation.constraints.NotNull;
+
 @EqualsAndHashCode(callSuper = true)
 @Data
 public class SignUpRequest extends AuthenticationRequest {
+    @NotNull
     private String username;
+    @NotNull
+    private String grantType;
+    
+    private String authProvider;
+    private String accessToken;
+    private String email;
+    private String password;
 
     // TODO: More information about region, preference... should be added
 }

--- a/src/main/java/com/wafflestudio/draft/repository/UserRepository.java
+++ b/src/main/java/com/wafflestudio/draft/repository/UserRepository.java
@@ -9,4 +9,6 @@ public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByEmail(String email);
 
     Optional<User> findByUsername(String username);
+
+    boolean existsUserByUsername(String username);
 }

--- a/src/main/java/com/wafflestudio/draft/service/UserService.java
+++ b/src/main/java/com/wafflestudio/draft/service/UserService.java
@@ -12,7 +12,11 @@ public class UserService {
     @Autowired
     private UserRepository userRepository;
 
-    public Optional<User> findUser(String email) {
+    public Optional<User> findUserByEmail(String email) {
         return userRepository.findByEmail(email);
+    }
+
+    public boolean existsUserByUsername(String username) {
+        return userRepository.existsUserByUsername(username);
     }
 }

--- a/src/test/java/com/wafflestudio/draft/service/RoomServiceTest.java
+++ b/src/test/java/com/wafflestudio/draft/service/RoomServiceTest.java
@@ -27,7 +27,7 @@ class RoomServiceTest {
     void create() throws Exception {
         // given
         Room room = new Room();
-        User user = userService.findUser("authuser@test.com").get();
+        User user = userService.findUserByEmail("authuser@test.com").get();
         room.setOwner(user);
 
         Court court = courtService.getCourtById(1L).get();


### PR DESCRIPTION
This PR will resolve #50 issue.

# Major Changes
## 1. Username이 중복이면 회원가입 시 409
- /api/v1/user/signup/

## 2. 회원가입 시 request가 valid한지 체크
- /api/v1/user/signup/의 request가 valid하지 않으면 400

## 2. Username이 중복인지 체크하는 /api/v1/user/check-username/ 개발
- String username을 request로 보내면 문제 없을 시 200, 중복이면 409로 response
