### PR TITLE
RoomApiController Test

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -65,6 +65,7 @@ dependencies {
 	testImplementation('org.springframework.boot:spring-boot-starter-test') {
 		exclude group: 'org.junit.vintage', module: 'junit-vintage-engine'
 	}
+	testImplementation('org.springframework.security:spring-security-test')
 }
 
 test {

--- a/src/main/java/com/wafflestudio/draft/DataLoader.java
+++ b/src/main/java/com/wafflestudio/draft/DataLoader.java
@@ -13,11 +13,13 @@ import com.wafflestudio.draft.service.RoomService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.boot.ApplicationArguments;
 import org.springframework.boot.ApplicationRunner;
+import org.springframework.context.annotation.Profile;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Component;
 
 import java.time.LocalDateTime;
 
+@Profile("!test")
 @Component
 @RequiredArgsConstructor
 public class DataLoader implements ApplicationRunner {

--- a/src/test/java/com/wafflestudio/draft/api/RoomApiControllerTest.java
+++ b/src/test/java/com/wafflestudio/draft/api/RoomApiControllerTest.java
@@ -1,0 +1,73 @@
+package com.wafflestudio.draft.api;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+
+import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
+import static org.hamcrest.CoreMatchers.is;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+
+// FIXME: This test is depending on DataLoader and other logics, which is not desirable as genuine unit test.
+// @ActiveProfiles("test")
+@ExtendWith(SpringExtension.class)
+@SpringBootTest
+@AutoConfigureMockMvc
+public class RoomApiControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    @WithMockUser
+    public void getRoomTest() throws Exception {
+        this.mockMvc.perform(get("/api/v1/room/{roomId}", 1).contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$['id']", is(1)))
+                .andExpect(jsonPath("$['name']", is("TEST_ROOM_1")));
+    }
+
+    @Test
+    @WithMockUser
+    public void getRoomsTest() throws Exception {
+        this.mockMvc.perform(get("/api/v1/room/").contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$", hasSize(5)))
+                .andExpect(jsonPath("$[4].id", is(5)))
+                .andExpect(jsonPath("$[4].name", is("TEST_ROOM_5")));
+
+        this.mockMvc.perform(get("/api/v1/room/")
+                .param("name", "TEST_ROOM_3").contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$", hasSize(1)))
+                .andExpect(jsonPath("$[0].id", is(3)))
+                .andExpect(jsonPath("$[0].name", is("TEST_ROOM_3")));
+
+        this.mockMvc.perform(get("/api/v1/room/")
+                .param("courtId", "1").contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$", hasSize(5)));
+
+        MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+        params.add("name", "TEST_ROOM_4");
+        params.add("courtId", "1");
+        this.mockMvc.perform(get("/api/v1/room/")
+                .params(params).contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$", hasSize(1)))
+                .andExpect(jsonPath("$[0].name", is("TEST_ROOM_4")));
+    }
+}

--- a/src/test/java/com/wafflestudio/draft/service/RoomServiceTest.java
+++ b/src/test/java/com/wafflestudio/draft/service/RoomServiceTest.java
@@ -3,34 +3,40 @@ package com.wafflestudio.draft.service;
 import com.wafflestudio.draft.model.Court;
 import com.wafflestudio.draft.model.Room;
 import com.wafflestudio.draft.model.User;
+import com.wafflestudio.draft.repository.CourtRepository;
 import com.wafflestudio.draft.repository.RoomRepository;
+import com.wafflestudio.draft.repository.UserRepository;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.transaction.annotation.Transactional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+@ActiveProfiles("test")
 @ExtendWith(SpringExtension.class)
 @SpringBootTest
 @Transactional
 class RoomServiceTest {
 
     @Autowired RoomService roomService;
-    @Autowired UserService userService;
-    @Autowired CourtService courtService;
     @Autowired RoomRepository roomRepository;
+    @Autowired UserRepository userRepository;
+    @Autowired CourtRepository courtRepository;
 
     @Test
     void create() throws Exception {
         // given
         Room room = new Room();
-        User user = userService.findUserByEmail("authuser@test.com").get();
+        User user = new User("TEST_USER", "user@test.com");
+        userRepository.save(user);
         room.setOwner(user);
 
-        Court court = courtService.getCourtById(1L).get();
+        Court court = new Court();
+        courtRepository.save(court);
         room.setCourt(court);
 
         // when

--- a/src/test/java/com/wafflestudio/draft/service/UserAuthTest.java
+++ b/src/test/java/com/wafflestudio/draft/service/UserAuthTest.java
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MockMvcBuilder;
@@ -15,6 +16,7 @@ import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
+@ActiveProfiles("test")
 @ExtendWith(SpringExtension.class)
 @SpringBootTest
 public class UserAuthTest {


### PR DESCRIPTION
This PR will resolve #61 issue.

# Major Changes
# 1. ApiController Test 추가
- 앞으로 ApiController들의 test를 용이하게 추가할 수 있도록, RoomApiControllerTest를 그 첫 테스트로서 추가합니다.

# 2. DataLoader에 test들이 의존하게 되는 것을 방지하고자 Profile 이용
- test들이 임시적이고 계속해서 바뀔 수 있는 DataLoader에 의존하는 것은 좋지 않아 보입니다. 따라서 "test" Profile에서는 DataLoader가 동작하지 않을 수 있도록 ActiveProfiles와 Profile을 적용했습니다.
- 다만 DataLoader에 의존하지 않고, 진정한 Unit test를 지키려면 Mocking을 여러 층위에서 잘 해야합니다. 현재로서는 ApiController의 test에 그렇게 잘 적용하기에는 이 부분이 아직 미숙하고, 그렇다고 Mocking하지 않고 여러 service, repository들을 이용해서 여러 model의 관계들을 다 만들어주고자(예를 들어 User, Court 등이 다 있어야 Room 하나를 만들 수 있음) 개별 test들에 setUp 또는 given 코드를 매번 반복되는 부분이 많게 넣어주는 것도 난감한 일이라, 우선 RoomApiControllerTest에 대해서는 일단 DataLoader의 데이터에 의존하도록 했습니다. 테스트 코드를 보면 알 수 있듯, 때문에 DataLoader에서 생성하는 방 개수를 5에서 6으로만 바꿔도 실패하는 테스트입니다.
- 프로젝트의 대부분 자원을 가져오는 SpringBootTest를 남발하는 것도 좋을지 비슷한 의미에서 고민입니다. WebMvcTest 등을 이용할 수도 있지 않을지.

# 3. API test시 권한 문제를 해결할 수 있도록 spring-security-test 추가
- WithMockUser를 사용하지 않으면 대부분의 API를 권한이 없어 정상적으로 호출할 수 없으므로 사용.
