### PR TITLE
add participants & profileImage info in roomresponse

### DIFF
--- a/src/main/java/com/wafflestudio/draft/api/RoomApiController.java
+++ b/src/main/java/com/wafflestudio/draft/api/RoomApiController.java
@@ -53,7 +53,7 @@ public class RoomApiController {
         room.setCourt(court.get());
         roomService.save(room);
         participantService.addParticipants(room, currentUser);
-        return new RoomResponse(room);
+        return roomService.makeRoomResponse(room);
     }
 
     @GetMapping(path = "{id}")
@@ -62,7 +62,7 @@ public class RoomApiController {
         if (room == null) {
             throw new ResponseStatusException(HttpStatus.NOT_FOUND);
         }
-        return new RoomResponse(room);
+        return roomService.makeRoomResponse(room);
     }
 
     @GetMapping("/")
@@ -78,7 +78,7 @@ public class RoomApiController {
         List<Room> rooms = roomService.findRooms(name, courtId, startTime, endTime);
         List<RoomResponse> getRoomsResponse = new ArrayList<>();
         for (Room room : rooms) {
-            getRoomsResponse.add(new RoomResponse(room));
+            getRoomsResponse.add(roomService.makeRoomResponse(room));
         }
         return getRoomsResponse;
     }
@@ -168,6 +168,6 @@ public class RoomApiController {
         }
 
         roomService.save(room);
-        return new RoomResponse(room);
+        return roomService.makeRoomResponse(room);
     }
 }

--- a/src/main/java/com/wafflestudio/draft/api/UserApiController.java
+++ b/src/main/java/com/wafflestudio/draft/api/UserApiController.java
@@ -2,10 +2,7 @@ package com.wafflestudio.draft.api;
 
 
 import com.wafflestudio.draft.dto.request.*;
-import com.wafflestudio.draft.dto.response.DeviceResponse;
-import com.wafflestudio.draft.dto.response.PreferenceInRegionResponse;
-import com.wafflestudio.draft.dto.response.RoomsOfUserResponse;
-import com.wafflestudio.draft.dto.response.UserInformationResponse;
+import com.wafflestudio.draft.dto.response.*;
 import com.wafflestudio.draft.model.*;
 import com.wafflestudio.draft.security.CurrentUser;
 import com.wafflestudio.draft.security.JwtTokenProvider;
@@ -140,6 +137,12 @@ public class UserApiController {
     @GetMapping("/room/")
     public RoomsOfUserResponse getBelongingRooms(@CurrentUser User currentUser) {
         List<Room> rooms = roomService.findRoomsByUser(currentUser);
-        return new RoomsOfUserResponse(currentUser, rooms);
+        RoomsOfUserResponse roomsOfUserResponse = new RoomsOfUserResponse(currentUser);
+        List<RoomResponse> roomResponses = new ArrayList<>();
+        for (Room room : rooms) {
+            roomResponses.add(roomService.makeRoomResponse(room));
+        }
+        roomsOfUserResponse.setRooms(roomResponses);
+        return roomsOfUserResponse;
     }
 }

--- a/src/main/java/com/wafflestudio/draft/dto/response/RoomResponse.java
+++ b/src/main/java/com/wafflestudio/draft/dto/response/RoomResponse.java
@@ -17,6 +17,7 @@ public class RoomResponse {
     private LocalDateTime createdAt;
     private Long ownerId;
     private Long courtId;
+    private ParticipantsResponse participants;
 
     public RoomResponse(Room room) {
         this.id = room.getId();

--- a/src/main/java/com/wafflestudio/draft/dto/response/RoomsOfUserResponse.java
+++ b/src/main/java/com/wafflestudio/draft/dto/response/RoomsOfUserResponse.java
@@ -14,14 +14,9 @@ public class RoomsOfUserResponse {
     private String email;
     private List<RoomResponse> rooms;
 
-    public RoomsOfUserResponse(User user, List<Room> rooms) {
+    public RoomsOfUserResponse(User user) {
         this.id = user.getId();
         this.username = user.getUsername();
         this.email = user.getEmail();
-        List<RoomResponse> roomResponses = new ArrayList<>();
-        for (Room room : rooms) {
-            roomResponses.add(new RoomResponse(room));
-        }
-        this.rooms = roomResponses;
     }
 }

--- a/src/main/java/com/wafflestudio/draft/dto/response/UserInformationResponse.java
+++ b/src/main/java/com/wafflestudio/draft/dto/response/UserInformationResponse.java
@@ -14,10 +14,12 @@ public class UserInformationResponse {
     private String username;
     @NonNull
     private String email;
+    private String profileImage;
 
     public UserInformationResponse(User user) {
         this.id = user.getId();
         this.username = user.getUsername();
         this.email = user.getEmail();
+        this.profileImage = user.getProfileImage();
     }
 }

--- a/src/main/java/com/wafflestudio/draft/model/User.java
+++ b/src/main/java/com/wafflestudio/draft/model/User.java
@@ -31,6 +31,9 @@ public class User extends BaseTimeEntity {
     private String password;
 
     @Column
+    private String profileImage;
+
+    @Column
     private String roles;
 
     @OneToMany(mappedBy = "owner")
@@ -46,5 +49,4 @@ public class User extends BaseTimeEntity {
     public void addRole(String role) {
         roles = roles + "," + role;
     }
-
 }

--- a/src/main/java/com/wafflestudio/draft/service/RoomService.java
+++ b/src/main/java/com/wafflestudio/draft/service/RoomService.java
@@ -1,5 +1,6 @@
 package com.wafflestudio.draft.service;
 
+import com.wafflestudio.draft.dto.response.RoomResponse;
 import com.wafflestudio.draft.model.Room;
 import com.wafflestudio.draft.model.User;
 import com.wafflestudio.draft.repository.RoomRepository;
@@ -16,6 +17,7 @@ import java.util.List;
 public class RoomService {
 
     private final RoomRepository roomRepository;
+    private final ParticipantService participantService;
 
     @Transactional
     public Long save(Room room) {
@@ -33,5 +35,11 @@ public class RoomService {
 
     public List<Room> findRoomsByUser(User user) {
         return roomRepository.findRoomsByUser(user);
+    }
+
+    public RoomResponse makeRoomResponse(Room room) {
+        RoomResponse roomResponse = new RoomResponse(room);
+        roomResponse.setParticipants(participantService.getParticipants(room));
+        return roomResponse;
     }
 }

--- a/src/test/java/com/wafflestudio/draft/api/RoomApiControllerTest.java
+++ b/src/test/java/com/wafflestudio/draft/api/RoomApiControllerTest.java
@@ -37,7 +37,9 @@ public class RoomApiControllerTest {
         this.mockMvc.perform(get("/api/v1/room/{roomId}", 1).contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$['id']", is(1)))
-                .andExpect(jsonPath("$['name']", is("TEST_ROOM_1")));
+                .andExpect(jsonPath("$['name']", is("TEST_ROOM_1")))
+                .andExpect(jsonPath("$['participants']['team1'][0]['id']", is(1)))
+                .andExpect(jsonPath("$['participants']['team2']", hasSize(0)));
     }
 
     @Test
@@ -47,7 +49,8 @@ public class RoomApiControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$", hasSize(5)))
                 .andExpect(jsonPath("$[4].id", is(5)))
-                .andExpect(jsonPath("$[4].name", is("TEST_ROOM_5")));
+                .andExpect(jsonPath("$[4].name", is("TEST_ROOM_5")))
+                .andExpect(jsonPath("$[4]['participants']['team1'][0]['id']", is(1)));
 
         this.mockMvc.perform(get("/api/v1/room/")
                 .param("name", "TEST_ROOM_3").contentType(MediaType.APPLICATION_JSON))


### PR DESCRIPTION
This PR will resolve #63 issue.

# Major Changes
## 1. RoomResponse를 갖는 API들의 response 내부에 participants에 대한 정보 추가
- `GET /api/v1/room/` 등 Room 관련 정보를 가져오는 API들에 participants에 대한 정보를 추가합니다.

```
[
    {
        "id": 1,
        "roomStatus": "WAITING",
        "startTime": "2020-08-15T13:34:08.256152",
        "endTime": "2020-08-15T14:34:08.256168",
        "name": "TEST_ROOM_1",
        "createdAt": "2020-08-15T13:34:08.265219",
        "ownerId": 1,
        "courtId": 1,
        "participants": {
            "team1": [
                {
                    "id": 1,
                    "username": "OAUTH2_TESTUSER",
                    "email": "authuser@test.com",
                    "profileImage": null
                }
            ],
            "team2": []
        }
    },
   ...
]
```

## 2. User model에 profileImage column 추가
- user의 profile image에 해당하는 image url을 저장하는 column을 추가하고, UserInformationResponse에 이를 추가합니다.
