### PR TITLE
listing rooms group by regions

### DIFF
--- a/src/main/kotlin/com/wafflestudio/draft/api/RoomApiController.kt
+++ b/src/main/kotlin/com/wafflestudio/draft/api/RoomApiController.kt
@@ -50,12 +50,12 @@ class RoomApiController(private val fcmService: FCMService, // FIXME: Use fcmSer
 
     @GetMapping("/")
     fun getRoomsV1(@ModelAttribute request: GetRoomsRequest): List<RoomInRegionResponse> {
+        // FIXME: query param for searching rooms will be used later
         var name = request.name
         if (name == null) {
             name = ""
         }
         val courtId = request.courtId
-        // FIXME: startTime and endTime for getting rooms will be used later
         val startTime = request.startTime
         val endTime = request.endTime
 

--- a/src/main/kotlin/com/wafflestudio/draft/api/RoomApiController.kt
+++ b/src/main/kotlin/com/wafflestudio/draft/api/RoomApiController.kt
@@ -4,16 +4,15 @@ import com.wafflestudio.draft.dto.request.CreateRoomRequest
 import com.wafflestudio.draft.dto.request.GetRoomsRequest
 import com.wafflestudio.draft.dto.request.PutRoomRequest
 import com.wafflestudio.draft.dto.response.ParticipantsResponse
+import com.wafflestudio.draft.dto.response.PreferenceInRegionResponse
+import com.wafflestudio.draft.dto.response.RoomInRegionResponse
 import com.wafflestudio.draft.dto.response.RoomResponse
 import com.wafflestudio.draft.model.Participant
 import com.wafflestudio.draft.model.Room
 import com.wafflestudio.draft.model.enums.RoomStatus
 import com.wafflestudio.draft.security.CurrentUser
 import com.wafflestudio.draft.security.password.UserPrincipal
-import com.wafflestudio.draft.service.CourtService
-import com.wafflestudio.draft.service.FCMService
-import com.wafflestudio.draft.service.ParticipantService
-import com.wafflestudio.draft.service.RoomService
+import com.wafflestudio.draft.service.*
 import org.springframework.http.HttpStatus
 import org.springframework.web.bind.annotation.*
 import org.springframework.web.server.ResponseStatusException
@@ -22,7 +21,8 @@ import javax.validation.Valid
 @RestController
 @RequestMapping("/api/v1/room")
 class RoomApiController(private val fcmService: FCMService, // FIXME: Use fcmService.send(message) when room create
-                        private val participantService: ParticipantService, private val roomService: RoomService, private val courtService: CourtService) {
+                        private val courtService: CourtService, private val participantService: ParticipantService,
+                        private val regionService: RegionService, private val roomService: RoomService) {
 
     @PostMapping("/")
     @ResponseStatus(HttpStatus.CREATED)
@@ -39,17 +39,17 @@ class RoomApiController(private val fcmService: FCMService, // FIXME: Use fcmSer
         room.court = court.get()
         roomService.save(room)
         participantService.addParticipants(room, currentUser.user)
-        return roomService.makeRoomResponse(room)
+        return RoomResponse(room)
     }
 
     @GetMapping(path = ["{id}"])
     fun getRoomV1(@PathVariable("id") id: Long): RoomResponse {
         val room = roomService.findOne(id) ?: throw ResponseStatusException(HttpStatus.NOT_FOUND)
-        return roomService.makeRoomResponse(room)
+        return RoomResponse(room)
     }
 
     @GetMapping("/")
-    fun getRoomsV1(@ModelAttribute request: GetRoomsRequest): List<RoomResponse> {
+    fun getRoomsV1(@ModelAttribute request: GetRoomsRequest): List<RoomInRegionResponse> {
         var name = request.name
         if (name == null) {
             name = ""
@@ -58,8 +58,9 @@ class RoomApiController(private val fcmService: FCMService, // FIXME: Use fcmSer
         // FIXME: startTime and endTime for getting rooms will be used later
         val startTime = request.startTime
         val endTime = request.endTime
-        val rooms = roomService.findRooms(name, courtId, startTime, endTime)
-        return rooms?.map { roomService.makeRoomResponse(it) } ?: emptyList()
+
+        val regions = regionService.getRegions()
+        return regions.map { RoomInRegionResponse(it!!) }
     }
 
     @PostMapping(path = ["{id}/participant"])
@@ -129,6 +130,6 @@ class RoomApiController(private val fcmService: FCMService, // FIXME: Use fcmSer
             room.status = status
         }
         roomService.save(room)
-        return roomService.makeRoomResponse(room)
+        return RoomResponse(room)
     }
 }

--- a/src/main/kotlin/com/wafflestudio/draft/api/UserApiController.kt
+++ b/src/main/kotlin/com/wafflestudio/draft/api/UserApiController.kt
@@ -1,10 +1,7 @@
 package com.wafflestudio.draft.api
 
 import com.wafflestudio.draft.dto.request.*
-import com.wafflestudio.draft.dto.response.DeviceResponse
-import com.wafflestudio.draft.dto.response.PreferenceInRegionResponse
-import com.wafflestudio.draft.dto.response.RoomsOfUserResponse
-import com.wafflestudio.draft.dto.response.UserInformationResponse
+import com.wafflestudio.draft.dto.response.*
 import com.wafflestudio.draft.model.Device
 import com.wafflestudio.draft.model.Room
 import com.wafflestudio.draft.model.User
@@ -120,7 +117,7 @@ class UserApiController(private val oAuth2Provider: OAuth2Provider,
     fun getBelongingRooms(@CurrentUser currentUser: UserPrincipal): RoomsOfUserResponse? {
         val rooms: List<Room>? = roomService.findRoomsByUser(currentUser.user)
         val roomsOfUserResponse = RoomsOfUserResponse(currentUser.user)
-        roomsOfUserResponse.rooms = rooms?.map { roomService.makeRoomResponse(it) } ?: emptyList()
+        roomsOfUserResponse.rooms = rooms?.map { RoomResponse(it) } ?: emptyList()
         return roomsOfUserResponse
     }
 }

--- a/src/main/kotlin/com/wafflestudio/draft/dto/response/RoomInRegionResponse.kt
+++ b/src/main/kotlin/com/wafflestudio/draft/dto/response/RoomInRegionResponse.kt
@@ -1,0 +1,25 @@
+package com.wafflestudio.draft.dto.response
+
+import com.wafflestudio.draft.model.Region
+
+class RoomInRegionResponse(
+        var id: Long? = null,
+        var name: String? = null,
+        var depth1: String? = null,
+        var depth2: String? = null,
+        var depth3: String? = null,
+        var rooms: List<RoomResponse>? = null
+) {
+    constructor(region: Region): this() {
+        this.id = region.id
+        this.name = region.name
+        this.depth1 = region.depth1
+        this.depth2 = region.depth2
+        this.depth3 = region.depth3
+        val roomResponses: MutableList<RoomResponse> = mutableListOf()
+        region.courts.map { court ->
+            court.rooms?.map { roomResponses.add(RoomResponse(it)) }
+        }
+        this.rooms = roomResponses;
+    }
+}

--- a/src/main/kotlin/com/wafflestudio/draft/dto/response/RoomResponse.kt
+++ b/src/main/kotlin/com/wafflestudio/draft/dto/response/RoomResponse.kt
@@ -13,16 +13,19 @@ data class RoomResponse(
         var createdAt: LocalDateTime? = null,
         var ownerId: Long? = null,
         var courtId: Long? = null,
-        var participants: ParticipantsResponse? = null
+        var participants: List<UserInformationResponse>? = null
 ) {
-    constructor(room: Room?) : this(
-            room!!.id,
-            room.status,
-            room.startTime,
-            room.endTime,
-            room.name,
-            room.createdAt,
-            room.owner!!.id,
-            room.court!!.id
-    )
+    constructor(room: Room): this() {
+        this.id = room.id
+        this.roomStatus = room.status
+        this.startTime = room.startTime
+        this.endTime = room.endTime
+        this.name = room.name
+        this.createdAt = room.createdAt
+        this.ownerId = room.owner!!.id
+        this.courtId = room.court!!.id
+        val userResponses: MutableList<UserInformationResponse> = mutableListOf()
+        room.participants?.map { userResponses.add(UserInformationResponse(it.user)) }
+        this.participants = userResponses
+    }
 }

--- a/src/main/kotlin/com/wafflestudio/draft/model/Region.kt
+++ b/src/main/kotlin/com/wafflestudio/draft/model/Region.kt
@@ -17,5 +17,8 @@ data class Region(
         var name: String? = null,
 
         @OneToMany(mappedBy = "region", cascade = [CascadeType.ALL])
-        var users: MutableList<User> = mutableListOf()
+        var users: MutableList<User> = mutableListOf(),
+
+        @OneToMany(mappedBy = "region", cascade = [CascadeType.ALL])
+        var courts: MutableList<Court> = mutableListOf()
 ) : BaseTimeEntity()

--- a/src/main/kotlin/com/wafflestudio/draft/service/CourtService.kt
+++ b/src/main/kotlin/com/wafflestudio/draft/service/CourtService.kt
@@ -12,6 +12,7 @@ import java.util.*
 class CourtService {
     @Autowired
     private val courtRepository: CourtRepository? = null
+
     fun getCourtById(id: Long?): Optional<Court?> {
         return courtRepository!!.findById(id!!)
     }

--- a/src/main/kotlin/com/wafflestudio/draft/service/RegionService.kt
+++ b/src/main/kotlin/com/wafflestudio/draft/service/RegionService.kt
@@ -1,6 +1,9 @@
 package com.wafflestudio.draft.service
 
+import com.wafflestudio.draft.dto.response.RoomResponse
+import com.wafflestudio.draft.model.Court
 import com.wafflestudio.draft.model.Region
+import com.wafflestudio.draft.model.Room
 import com.wafflestudio.draft.repository.RegionRepository
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Service
@@ -12,11 +15,16 @@ import java.util.*
 class RegionService {
     @Autowired
     private val regionRepository: RegionRepository? = null
+
     fun findRegionById(id: Long?): Optional<Region?>? {
         return regionRepository!!.findById(id!!)
     }
 
     fun findRegionsByName(name: String?): List<Region>? {
         return regionRepository!!.findByNameContaining(name)
+    }
+
+    fun getRegions(): MutableList<Region?> {
+        return regionRepository!!.findAll()
     }
 }

--- a/src/main/kotlin/com/wafflestudio/draft/service/RoomService.kt
+++ b/src/main/kotlin/com/wafflestudio/draft/service/RoomService.kt
@@ -29,10 +29,4 @@ class RoomService(private val roomRepository: RoomRepository, private val partic
     fun findRoomsByUser(user: User): List<Room>? {
         return roomRepository.findRoomsByUser(user)
     }
-
-    fun makeRoomResponse(room: Room): RoomResponse {
-        val roomResponse = RoomResponse(room)
-        roomResponse.participants = (participantService.getParticipants(room))
-        return roomResponse
-    }
 }

--- a/src/test/java/com/wafflestudio/draft/api/RoomApiControllerTest.java
+++ b/src/test/java/com/wafflestudio/draft/api/RoomApiControllerTest.java
@@ -38,8 +38,8 @@ public class RoomApiControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$['id']", is(1)))
                 .andExpect(jsonPath("$['name']", is("TEST_ROOM_1")))
-                .andExpect(jsonPath("$['participants']['team1'][0]['id']", is(1)))
-                .andExpect(jsonPath("$['participants']['team2']", hasSize(0)));
+                .andExpect(jsonPath("$['participants']", hasSize(1)))
+                .andExpect(jsonPath("$['participants'][0]['id']", is(1)));
     }
 
     @Test
@@ -47,30 +47,33 @@ public class RoomApiControllerTest {
     public void getRoomsTest() throws Exception {
         this.mockMvc.perform(get("/api/v1/room/").contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$", hasSize(5)))
-                .andExpect(jsonPath("$[4].id", is(5)))
-                .andExpect(jsonPath("$[4].name", is("TEST_ROOM_5")))
-                .andExpect(jsonPath("$[4]['participants']['team1'][0]['id']", is(1)));
-
-        this.mockMvc.perform(get("/api/v1/room/")
-                .param("name", "TEST_ROOM_3").contentType(MediaType.APPLICATION_JSON))
-                .andExpect(status().isOk())
                 .andExpect(jsonPath("$", hasSize(1)))
-                .andExpect(jsonPath("$[0].id", is(3)))
-                .andExpect(jsonPath("$[0].name", is("TEST_ROOM_3")));
+                .andExpect(jsonPath("$[0].id", is(1)))
+                .andExpect(jsonPath("$[0].name", is("TEST_REGION")))
+                .andExpect(jsonPath("$[0]['rooms']", hasSize(5)))
+                .andExpect(jsonPath("$[0]['rooms'][4].name", is("TEST_ROOM_5")))
+                .andExpect(jsonPath("$[0]['rooms'][4]['participants']", hasSize(1)));
 
-        this.mockMvc.perform(get("/api/v1/room/")
-                .param("courtId", "1").contentType(MediaType.APPLICATION_JSON))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$", hasSize(5)));
-
-        MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
-        params.add("name", "TEST_ROOM_4");
-        params.add("courtId", "1");
-        this.mockMvc.perform(get("/api/v1/room/")
-                .params(params).contentType(MediaType.APPLICATION_JSON))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$", hasSize(1)))
-                .andExpect(jsonPath("$[0].name", is("TEST_ROOM_4")));
+        // FIXME: query param for searching rooms will be used later
+//        this.mockMvc.perform(get("/api/v1/room/")
+//                .param("name", "TEST_ROOM_3").contentType(MediaType.APPLICATION_JSON))
+//                .andExpect(status().isOk())
+//                .andExpect(jsonPath("$", hasSize(1)))
+//                .andExpect(jsonPath("$[0].id", is(3)))
+//                .andExpect(jsonPath("$[0].name", is("TEST_ROOM_3")));
+//
+//        this.mockMvc.perform(get("/api/v1/room/")
+//                .param("courtId", "1").contentType(MediaType.APPLICATION_JSON))
+//                .andExpect(status().isOk())
+//                .andExpect(jsonPath("$", hasSize(5)));
+//
+//        MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+//        params.add("name", "TEST_ROOM_4");
+//        params.add("courtId", "1");
+//        this.mockMvc.perform(get("/api/v1/room/")
+//                .params(params).contentType(MediaType.APPLICATION_JSON))
+//                .andExpect(status().isOk())
+//                .andExpect(jsonPath("$", hasSize(1)))
+//                .andExpect(jsonPath("$[0].name", is("TEST_ROOM_4")));
     }
 }


### PR DESCRIPTION
This PR is related with #67 issue.
related cards: https://trello.com/c/xntMpzLs

# Major Changes
## 1. Room List API가 Region 단위로 Room들을 listing하도록 변경
- #67 에서 언급된대로, GET /api/v1/room/ 이 Region 단위로 Room들을 listing하도록 함

```
[
    {
        "id": 1,
        "name": "TEST_REGION",
        "depth1": null,
        "depth2": null,
        "depth3": null,
        "rooms": [
            {
                "id": 1,
                "roomStatus": "WAITING",
                "startTime": "2020-10-24T06:02:47.046349",
                "endTime": "2020-10-24T07:02:47.04637",
                "name": "TEST_ROOM_1",
                "createdAt": null,
                "ownerId": 1,
                "courtId": 1,
                "participants": [
                    {
                        "id": 1,
                        "username": "OAUTH2_TESTUSER",
                        "email": "authuser@test.com",
                        "profileImage": "https://lh3.googleusercontent.com/-XdUIqdMkCWA/AAAAAAAAAAI/AAAAAAAAAAA/4252rscbv5M/photo.jpg"
                    },
                    ...participant들
                ]
            },
            ...room들
        ]
    },
    ...region들
]
```

- name, courtId 등 각종 query param에 대한 검색 지원은 https://trello.com/c/slV3GrWb 작업에서 진행할 예정.

## 2. Room API들의 response에서 pariticipants가 team 단위로 구분되어있던 것을 변경
- 간소해진 기획에 따라 room의 participants를 team 단위로 구분하지 않고, user들의 정보를 모두 동일하게 array로 나열
- 이에 따라 RoomService의 makeRoomResponse() 제거
- 참여/나가기 등 participant 관련 API의 경우는 여전히 team 단위 response를 갖고 있음. 추후 변경 해야함

개발 과정 발견한 known-issue
- POST /api/v1/room/ 등, Room 관련 API 중 DB에 participant를 insert하는 등의 API에서, room을 먼저 SELECT해오고 UPDATE나 INSERT가 이뤄져서, 먼저 가져왔던 room이 최종적으로 그 API에서 DB에 commit하는 최신 상황을 반영하지 못하는 경우가 있음.
  - 예를 들어, 방을 막 생성했을 때 그 response에 있는 room에 자신이 pariticipants에 포함되어야 하는데, 비어있음. 나중에 그 방을 다시 GET 해보면 포함되어 있음.
