### PR TITLE
GET /api/v1/region/room/

### DIFF
--- a/src/main/kotlin/com/wafflestudio/draft/api/RegionApiController.kt
+++ b/src/main/kotlin/com/wafflestudio/draft/api/RegionApiController.kt
@@ -1,7 +1,9 @@
 package com.wafflestudio.draft.api
 
 import com.wafflestudio.draft.dto.request.GetRegionsRequest
+import com.wafflestudio.draft.dto.request.GetRoomsRequest
 import com.wafflestudio.draft.dto.response.RegionResponse
+import com.wafflestudio.draft.dto.response.RoomInRegionResponse
 import com.wafflestudio.draft.service.RegionService
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.ModelAttribute
@@ -22,5 +24,11 @@ class RegionApiController(private val regionService: RegionService) {
         return regions?.map {
             RegionResponse(it)
         } ?: emptyList()
+    }
+
+    @GetMapping("/room/")
+    fun getRoomsV1(@ModelAttribute request: GetRoomsRequest): List<RoomInRegionResponse> {
+        val regions = regionService.getRegions()
+        return regions.map { RoomInRegionResponse(it!!) }
     }
 }

--- a/src/main/kotlin/com/wafflestudio/draft/api/RoomApiController.kt
+++ b/src/main/kotlin/com/wafflestudio/draft/api/RoomApiController.kt
@@ -48,21 +48,6 @@ class RoomApiController(private val fcmService: FCMService, // FIXME: Use fcmSer
         return RoomResponse(room)
     }
 
-    @GetMapping("/")
-    fun getRoomsV1(@ModelAttribute request: GetRoomsRequest): List<RoomInRegionResponse> {
-        // FIXME: query param for searching rooms will be used later
-        var name = request.name
-        if (name == null) {
-            name = ""
-        }
-        val courtId = request.courtId
-        val startTime = request.startTime
-        val endTime = request.endTime
-
-        val regions = regionService.getRegions()
-        return regions.map { RoomInRegionResponse(it!!) }
-    }
-
     @PostMapping(path = ["{id}/participant"])
     fun participate(@PathVariable("id") id: Long, @CurrentUser currentUser: UserPrincipal): ParticipantsResponse? {
         val room: Room = roomService.findOne(id) ?: throw ResponseStatusException(HttpStatus.NOT_FOUND)

--- a/src/test/java/com/wafflestudio/draft/api/RegionApiControllerTest.java
+++ b/src/test/java/com/wafflestudio/draft/api/RegionApiControllerTest.java
@@ -1,0 +1,42 @@
+package com.wafflestudio.draft.api;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+
+// FIXME: This test is depending on DataLoader and other logics, which is not desirable as genuine unit test.
+// @ActiveProfiles("test")
+@ExtendWith(SpringExtension.class)
+@SpringBootTest
+@AutoConfigureMockMvc
+public class RegionApiControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    @WithMockUser
+    public void getRegionRoomTest() throws Exception {
+        this.mockMvc.perform(get("/api/v1/region/room/").contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$", hasSize(1)))
+                .andExpect(jsonPath("$[0].id", is(1)))
+                .andExpect(jsonPath("$[0].name", is("TEST_REGION")))
+                .andExpect(jsonPath("$[0]['rooms']", hasSize(5)))
+                .andExpect(jsonPath("$[0]['rooms'][4].name", is("TEST_ROOM_5")))
+                .andExpect(jsonPath("$[0]['rooms'][4]['participants']", hasSize(1)));
+    }
+}

--- a/src/test/java/com/wafflestudio/draft/api/RoomApiControllerTest.java
+++ b/src/test/java/com/wafflestudio/draft/api/RoomApiControllerTest.java
@@ -45,15 +45,6 @@ public class RoomApiControllerTest {
     @Test
     @WithMockUser
     public void getRoomsTest() throws Exception {
-        this.mockMvc.perform(get("/api/v1/room/").contentType(MediaType.APPLICATION_JSON))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$", hasSize(1)))
-                .andExpect(jsonPath("$[0].id", is(1)))
-                .andExpect(jsonPath("$[0].name", is("TEST_REGION")))
-                .andExpect(jsonPath("$[0]['rooms']", hasSize(5)))
-                .andExpect(jsonPath("$[0]['rooms'][4].name", is("TEST_ROOM_5")))
-                .andExpect(jsonPath("$[0]['rooms'][4]['participants']", hasSize(1)));
-
         // FIXME: query param for searching rooms will be used later
 //        this.mockMvc.perform(get("/api/v1/room/")
 //                .param("name", "TEST_ROOM_3").contentType(MediaType.APPLICATION_JSON))


### PR DESCRIPTION
### 1.
- `GET /api/v1/room/` -> `GET /api/v1/region/room/`로 변경.
- 위치 기반 Main List 화면에서 사용될 예정
  - <img width="373" alt="스크린샷 2020-10-25 16 54 00" src="https://user-images.githubusercontent.com/35535636/97101679-b466fb80-16e2-11eb-9888-adb35c62879b.png">

### 2.
- `GET /api/v1/room/`은 검색 화면에서 사용될 예정. request body에 검색 요소들을 client가 넣어 보냄.
  - <img width="351" alt="스크린샷 2020-10-25 16 54 57" src="https://user-images.githubusercontent.com/35535636/97101700-d1033380-16e2-11eb-8857-eaa2e1c786a0.png">
