### PR TITLE
mysql -> postgresql

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ services:
 
 before-install:
   - psql -c 'CREATE DATABASE draft;' -U postgres
-  - psql -e "CREATE USER draft PASSWORD 'draft-pw';"
+  - psql -c "CREATE USER draft PASSWORD 'draft-pw';"
 
 install:
   - ./gradlew assemble

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,13 +13,12 @@ os: linux
 dist: xenial
 jdk: openjdk11
 services:
-  - mysql
+  - postgresql
   - redis
 
 before-install:
-  - mysql -e "CREATE DATABASE draft;"
-  - mysql -e "CREATE USER 'draft-admin'@'localhost' IDENTIFIED BY 'draft-pw';"
-  - mysql -e "GRANT ALL PRIVILEGES ON *.* to 'draft-admin'@'localhost';"
+  - psql -c 'CREATE DATABASE draft;' -U postgres
+  - psql -e "CREATE USER draft PASSWORD 'draft-pw';"
 
 install:
   - ./gradlew assemble

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -32,7 +32,7 @@ dependencies {
 
     implementation ("org.springframework.boot:spring-boot-starter-jdbc")
     implementation ("org.springframework.boot:spring-boot-starter-data-jpa")
-    runtimeOnly ("mysql:mysql-connector-java")
+    runtimeOnly("org.postgresql:postgresql")
 
     // Geomety
     implementation ("com.vividsolutions:jts:1.13")

--- a/src/main/kotlin/com/wafflestudio/draft/model/User.kt
+++ b/src/main/kotlin/com/wafflestudio/draft/model/User.kt
@@ -3,6 +3,7 @@ package com.wafflestudio.draft.model
 import javax.persistence.*
 
 @Entity
+@Table(name = "draft_user")
 data class User(
         @Column(unique = true)
         var username: String,

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,9 +1,8 @@
 spring:
   datasource:
-    driver-class-name: com.mysql.cj.jdbc.Driver
-    jdbc-url: jdbc:mysql://localhost:3306/draft?serverTimezone=UTC
-    username: draft-admin
-    password: draft-pw
+    jdbc-url: jdbc:postgresql://localhost:5432/draft?serverTimezone=UTC
+    username: draft
+    password: coffee-urban
   jpa:
     hibernate:
       ddl-auto: create

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -2,7 +2,7 @@ spring:
   datasource:
     jdbc-url: jdbc:postgresql://localhost:5432/draft?serverTimezone=UTC
     username: draft
-    password: coffee-urban
+    password: draft-pw
   jpa:
     hibernate:
       ddl-auto: create

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -2,10 +2,9 @@
 
 spring:
   datasource:
-    driver-class-name: com.mysql.cj.jdbc.Driver
-    jdbc-url: jdbc:mysql://localhost:3306/draft?serverTimezone=UTC
-    username: draft-admin
-    password: draft-pw
+    jdbc-url: jdbc:postgresql://localhost:5432/draft?serverTimezone=UTC
+    username: draft
+    password: coffee-urban
   jpa:
     hibernate:
       ddl-auto: create

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -4,7 +4,7 @@ spring:
   datasource:
     jdbc-url: jdbc:postgresql://localhost:5432/draft?serverTimezone=UTC
     username: draft
-    password: coffee-urban
+    password: draft-pw
   jpa:
     hibernate:
       ddl-auto: create


### PR DESCRIPTION
AWS RDS에 PostgreSQL 엔진인 draft-db도 생성했습니다. 비밀번호 등은 Slack에서 공유하고 merge되면 배포 환경에 해당 DB에 연결하도록 설정해두겠습니다. MySQL RDS는 merge해서 PostgreSQL에 대한 배포 설정이 끝나면 중단하겠습니다.

PostgreSQL에서 'user'가 reserved된 어휘라 table 이름으로 draft_user 를 사용하도록 했습니다.

PostgreSQL user 이름에 일반적으로 '-'를 포함시킬 수 없습니다. 로컬 세팅에 참고하시기 바랍니다.
