### PR TITLE
Search Room API basic & Get Courts API

### DIFF
--- a/src/main/kotlin/com/wafflestudio/draft/api/CourtApiController.kt
+++ b/src/main/kotlin/com/wafflestudio/draft/api/CourtApiController.kt
@@ -1,0 +1,26 @@
+package com.wafflestudio.draft.api
+
+import com.wafflestudio.draft.dto.request.GetCourtsRequest
+import com.wafflestudio.draft.dto.response.CourtResponse
+import com.wafflestudio.draft.service.CourtService
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.ModelAttribute
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+import javax.validation.Valid
+
+@RestController
+@RequestMapping("/api/v1/court")
+class CourtApiController(private val courtService: CourtService) {
+    @GetMapping("/")
+    fun getCourtsV1(@Valid @ModelAttribute request: GetCourtsRequest): List<CourtResponse> {
+        var name = request.name
+        if (name == null) {
+            name = ""
+        }
+        val courts = courtService.findCourtsByName(name)
+        return courts?.map {
+            CourtResponse(it)
+        } ?: emptyList()
+    }
+}

--- a/src/main/kotlin/com/wafflestudio/draft/api/RoomApiController.kt
+++ b/src/main/kotlin/com/wafflestudio/draft/api/RoomApiController.kt
@@ -42,6 +42,20 @@ class RoomApiController(private val fcmService: FCMService, // FIXME: Use fcmSer
         return RoomResponse(room)
     }
 
+    @GetMapping("/")
+    fun getRoomsV1(@ModelAttribute request: GetRoomsRequest): List<RoomResponse> {
+        var name = request.name
+        if (name == null) {
+            name = ""
+        }
+        val regionId = request.regionId
+        val startTime = request.startTime
+        val endTime = request.endTime
+
+        val rooms = roomService.findRooms(name, regionId, startTime, endTime)
+        return rooms!!.map { RoomResponse(it) }
+    }
+
     @GetMapping(path = ["{id}"])
     fun getRoomV1(@PathVariable("id") id: Long): RoomResponse {
         val room = roomService.findOne(id) ?: throw ResponseStatusException(HttpStatus.NOT_FOUND)

--- a/src/main/kotlin/com/wafflestudio/draft/dto/request/GetCourtsRequest.kt
+++ b/src/main/kotlin/com/wafflestudio/draft/dto/request/GetCourtsRequest.kt
@@ -1,0 +1,5 @@
+package com.wafflestudio.draft.dto.request
+
+data class GetCourtsRequest(
+        val name: String? = null
+)

--- a/src/main/kotlin/com/wafflestudio/draft/dto/request/GetRoomsRequest.kt
+++ b/src/main/kotlin/com/wafflestudio/draft/dto/request/GetRoomsRequest.kt
@@ -10,5 +10,5 @@ data class GetRoomsRequest(
         @DateTimeFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
         var endTime: LocalDateTime? = null,
         var name: String? = null,
-        var courtId: Long? = null
+        var regionId: Long? = null
 )

--- a/src/main/kotlin/com/wafflestudio/draft/dto/response/CourtResponse.kt
+++ b/src/main/kotlin/com/wafflestudio/draft/dto/response/CourtResponse.kt
@@ -1,0 +1,17 @@
+package com.wafflestudio.draft.dto.response
+
+import com.wafflestudio.draft.model.Court
+
+data class CourtResponse(
+        var id: Long? = null,
+        var regionId: Long? = null,
+        var name: String? = null,
+        var capacity: Int? = null
+) {
+    constructor(court: Court) : this(
+            court.id,
+            court.region!!.id,
+            court.name,
+            court.capacity
+    )
+}

--- a/src/main/kotlin/com/wafflestudio/draft/repository/CourtRepository.kt
+++ b/src/main/kotlin/com/wafflestudio/draft/repository/CourtRepository.kt
@@ -3,4 +3,6 @@ package com.wafflestudio.draft.repository
 import com.wafflestudio.draft.model.Court
 import org.springframework.data.jpa.repository.JpaRepository
 
-interface CourtRepository : JpaRepository<Court?, Long?>
+interface CourtRepository : JpaRepository<Court?, Long?> {
+    fun findByNameContaining(name: String?): List<Court>?
+}

--- a/src/main/kotlin/com/wafflestudio/draft/repository/RoomRepository.kt
+++ b/src/main/kotlin/com/wafflestudio/draft/repository/RoomRepository.kt
@@ -16,11 +16,10 @@ class RoomRepository(private val em: EntityManager) {
         return em.find(Room::class.java, id)
     }
 
-    fun findRooms(name: String?, courtId: Long?, startTime: LocalDateTime?, endTime: LocalDateTime?): List<Room>? {
+    fun findRooms(name: String?, regionId: Long?, startTime: LocalDateTime?, endTime: LocalDateTime?): List<Room>? {
         // FIXME: we should find a smarter way...
-        return if (courtId == null) {
+        return if (regionId == null) {
             em.createQuery("SELECT r FROM Room r " +
-                    "INNER JOIN r.court c " +
                     "WHERE r.name LIKE '%'||:name||'%' "
                     , Room::class.java)
                     .setParameter("name", name)
@@ -28,11 +27,12 @@ class RoomRepository(private val em: EntityManager) {
         } else {
             em.createQuery("SELECT r FROM Room r " +
                     "INNER JOIN r.court c " +
+                    "INNER JOIN c.region reg " +
                     "WHERE r.name LIKE '%'||:name||'%' " +
-                    "AND c.id = :court_id"
+                    "AND reg.id = :region_id"
                     , Room::class.java)
                     .setParameter("name", name)
-                    .setParameter("court_id", courtId)
+                    .setParameter("region_id", regionId)
                     .resultList
         }
     }

--- a/src/main/kotlin/com/wafflestudio/draft/service/CourtService.kt
+++ b/src/main/kotlin/com/wafflestudio/draft/service/CourtService.kt
@@ -16,4 +16,8 @@ class CourtService {
     fun getCourtById(id: Long?): Optional<Court?> {
         return courtRepository!!.findById(id!!)
     }
+
+    fun findCourtsByName(name: String?): List<Court>? {
+        return courtRepository!!.findByNameContaining(name)
+    }
 }

--- a/src/main/kotlin/com/wafflestudio/draft/service/RegionService.kt
+++ b/src/main/kotlin/com/wafflestudio/draft/service/RegionService.kt
@@ -1,9 +1,6 @@
 package com.wafflestudio.draft.service
 
-import com.wafflestudio.draft.dto.response.RoomResponse
-import com.wafflestudio.draft.model.Court
 import com.wafflestudio.draft.model.Region
-import com.wafflestudio.draft.model.Room
 import com.wafflestudio.draft.repository.RegionRepository
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Service

--- a/src/main/kotlin/com/wafflestudio/draft/service/RoomService.kt
+++ b/src/main/kotlin/com/wafflestudio/draft/service/RoomService.kt
@@ -17,8 +17,8 @@ class RoomService(private val roomRepository: RoomRepository, private val partic
         return room.id
     }
 
-    fun findRooms(name: String?, courtId: Long?, startTime: LocalDateTime?, endTime: LocalDateTime?): List<Room>? {
-        return roomRepository.findRooms(name, courtId, startTime, endTime)
+    fun findRooms(name: String?, regionId: Long?, startTime: LocalDateTime?, endTime: LocalDateTime?): List<Room>? {
+        return roomRepository.findRooms(name, regionId, startTime, endTime)
     }
 
     fun findOne(roomId: Long): Room? {


### PR DESCRIPTION
# Major Changes
## 1. GET /api/v1/room/ 에서 name, regionId 에 따른 검색 지원
- query param으로 name, regionId를 받아 검색된 결과를 돌려줍니다. 아직 startTime, endTime은 지원하지 않습니다.
- 추후 response의 전체적인 형태가 array가 아닌, dict형태로 하고 results라는 key의 내부에 array를 포함시켜야 합니다. (그 외 key로 전체 개수 count, 다음 page 번호를 가리키는 next가 들어갑니다) API 문서에는 미래에 될 방식대로 적혀있습니다.


## 2. GET /api/v1/court/ 생성
- 방 생성 API(POST /api/v1/room/) 등에서 클라이언트가 courtId로 보내야하는데, 앱 처음 접속시 클라이언트가 서버로부터 region, court 정보를 받아와야합니다. GET /api/v1/region/ 은 이미 있으므로, GET /api/v1/court/ 를 개발했습니다.
- 추후 response의 전체적인 형태가 array가 아닌, dict형태로 하고 results라는 key의 내부에 array를 포함시켜야 합니다. (그 외 key로 전체 개수 count, 다음 page 번호를 가리키는 next가 들어갑니다)