### PR TITLE
Update RegionRepository not to fetch geometry data

### DIFF
--- a/src/main/kotlin/com/wafflestudio/draft/api/RegionApiController.kt
+++ b/src/main/kotlin/com/wafflestudio/draft/api/RegionApiController.kt
@@ -20,10 +20,7 @@ class RegionApiController(private val regionService: RegionService) {
         if (name == null) {
             name = ""
         }
-        val regions = regionService.findRegionsByName(name)
-        return regions?.map {
-            RegionResponse(it)
-        } ?: emptyList()
+        return regionService.findRegionsByName(name).orEmpty()
     }
 
     @GetMapping("/room/")

--- a/src/main/kotlin/com/wafflestudio/draft/model/Region.kt
+++ b/src/main/kotlin/com/wafflestudio/draft/model/Region.kt
@@ -14,7 +14,6 @@ class Region(
         var depth3: String? = null,
 
         @Column(nullable = false, columnDefinition = "Geometry(MultiPolygon,5179)")
-        @Basic(fetch = FetchType.LAZY)
         var polygon: MultiPolygon,
 
         @Column(unique = true)

--- a/src/main/kotlin/com/wafflestudio/draft/repository/RegionRepository.kt
+++ b/src/main/kotlin/com/wafflestudio/draft/repository/RegionRepository.kt
@@ -1,5 +1,6 @@
 package com.wafflestudio.draft.repository
 
+import com.wafflestudio.draft.dto.response.RegionResponse
 import com.wafflestudio.draft.model.Region
 import org.locationtech.jts.geom.Point
 import org.springframework.data.jpa.repository.JpaRepository
@@ -9,13 +10,13 @@ import java.util.*
 
 interface RegionRepository : JpaRepository<Region?, Long?> {
     override fun findById(id: Long): Optional<Region?>
-    fun findByNameContaining(name: String?): List<Region>?
+    fun findByNameContaining(name: String?): List<RegionResponse>?
 
-    @Query("SELECT r FROM Region r " +
+    @Query("SELECT r.id,r.name,r.depth1,r.depth2,r.depth3 FROM Region r " +
             "WHERE CONTAINS(r.polygon, ST_SetSRID(ST_MakePoint(:lon,:lat),4326))=true")
-    fun findRegionByPolygonContainsCoordinate(@Param("lat") lat: Double, @Param("lon") lon: Double): List<Region>?
+    fun findRegionByPolygonContainsCoordinate(@Param("lat") lat: Double, @Param("lon") lon: Double): List<RegionResponse>?
 
-    @Query("SELECT r FROM Region r " +
+    @Query("SELECT r.id,r.name,r.depth1,r.depth2,r.depth3 FROM Region r " +
             "WHERE CONTAINS(r.polygon, :point)=true")
-    fun findRegionByPolygonContainsPoint(@Param("point") point: Point): List<Region>?
+    fun findRegionByPolygonContainsPoint(@Param("point") point: Point): List<RegionResponse>?
 }

--- a/src/main/kotlin/com/wafflestudio/draft/service/RegionService.kt
+++ b/src/main/kotlin/com/wafflestudio/draft/service/RegionService.kt
@@ -1,5 +1,6 @@
 package com.wafflestudio.draft.service
 
+import com.wafflestudio.draft.dto.response.RegionResponse
 import com.wafflestudio.draft.model.Region
 import com.wafflestudio.draft.repository.RegionRepository
 import org.springframework.beans.factory.annotation.Autowired
@@ -17,7 +18,7 @@ class RegionService {
         return regionRepository!!.findById(id!!)
     }
 
-    fun findRegionsByName(name: String?): List<Region>? {
+    fun findRegionsByName(name: String?): List<RegionResponse>? {
         return regionRepository!!.findByNameContaining(name)
     }
 


### PR DESCRIPTION
## 변경사항
현재 
```Kotlin
@Entity
class Region(
        @Column(nullable = false, columnDefinition = "Geometry(MultiPolygon,5179)")
        @Basic(fetch = FetchType.LAZY)
        var polygon: MultiPolygon,
```
에서 lazy fetch가 정상적으로 동작하지 않아 fetch시에 dbms밖에서 사용할 일 없는 매우 큰 데이터를 가져오는 중이라
DTO를 이용해 geometry 데이터를 가져오지 않게 설정.

하지만 이렇게 하는 게 깔끔하지 않은 느낌이 들긴 한데 좋은 방법이 있을지 더 알아봐야 할 듯