### PR TITLE
use JpaRepository for RoomRepository & rest api errorhandling

### DIFF
--- a/src/main/kotlin/com/wafflestudio/draft/api/RoomApiController.kt
+++ b/src/main/kotlin/com/wafflestudio/draft/api/RoomApiController.kt
@@ -51,7 +51,7 @@ class RoomApiController(private val fcmService: FCMService, // FIXME: Use fcmSer
 
     @GetMapping(path = ["{id}"])
     fun getRoomV1(@PathVariable("id") id: Long): RoomResponse {
-        val room = roomService.findOne(id) ?: throw ResponseStatusException(HttpStatus.NOT_FOUND)
+        val room = roomService.findOne(id)
         return RoomResponse(room)
     }
 

--- a/src/main/kotlin/com/wafflestudio/draft/error/DraftException.kt
+++ b/src/main/kotlin/com/wafflestudio/draft/error/DraftException.kt
@@ -1,0 +1,7 @@
+package com.wafflestudio.draft.error
+
+import java.lang.RuntimeException
+
+open class DraftException(val errorType: ErrorType) : RuntimeException(errorType.name)
+
+class RoomNotFoundException : DraftException(ErrorType.ROOM_NOT_FOUND)

--- a/src/main/kotlin/com/wafflestudio/draft/error/DraftRestControllerAdvice.kt
+++ b/src/main/kotlin/com/wafflestudio/draft/error/DraftRestControllerAdvice.kt
@@ -15,6 +15,6 @@ class DraftRestControllerAdvice() {
     ): ErrorResponse {
         val errorType = e.errorType
         response.status = errorType.httpStatus.value()
-        return ErrorResponse(errorType.code, errorType.name.toLowerCase(), null)
+        return ErrorResponse(errorType.code, errorType.name.toLowerCase())
     }
 }

--- a/src/main/kotlin/com/wafflestudio/draft/error/DraftRestControllerAdvice.kt
+++ b/src/main/kotlin/com/wafflestudio/draft/error/DraftRestControllerAdvice.kt
@@ -1,0 +1,20 @@
+package com.wafflestudio.draft.error
+
+import org.springframework.web.bind.annotation.ExceptionHandler
+import org.springframework.web.bind.annotation.RestControllerAdvice
+import javax.servlet.http.HttpServletRequest
+import javax.servlet.http.HttpServletResponse
+
+@RestControllerAdvice
+class DraftRestControllerAdvice() {
+    @ExceptionHandler(DraftException::class)
+    fun handleDraftException(
+            e: DraftException,
+            request: HttpServletRequest,
+            response: HttpServletResponse
+    ): ErrorResponse {
+        val errorType = e.errorType
+        response.status = errorType.httpStatus.value()
+        return ErrorResponse(errorType.code, errorType.name.toLowerCase(), null)
+    }
+}

--- a/src/main/kotlin/com/wafflestudio/draft/error/ErrorResponse.kt
+++ b/src/main/kotlin/com/wafflestudio/draft/error/ErrorResponse.kt
@@ -2,6 +2,5 @@ package com.wafflestudio.draft.error
 
 data class ErrorResponse(
         val errorCode: Int,
-        val errorMessage: String?,
-        val validation: Map<String, String>?
+        val errorMessage: String?
 )

--- a/src/main/kotlin/com/wafflestudio/draft/error/ErrorResponse.kt
+++ b/src/main/kotlin/com/wafflestudio/draft/error/ErrorResponse.kt
@@ -1,0 +1,7 @@
+package com.wafflestudio.draft.error
+
+data class ErrorResponse(
+        val errorCode: Int,
+        val errorMessage: String?,
+        val validation: Map<String, String>?
+)

--- a/src/main/kotlin/com/wafflestudio/draft/error/ErrorType.kt
+++ b/src/main/kotlin/com/wafflestudio/draft/error/ErrorType.kt
@@ -1,0 +1,10 @@
+package com.wafflestudio.draft.error;
+
+import org.springframework.http.HttpStatus
+
+enum class ErrorType (
+    val code: Int,
+    val httpStatus: HttpStatus
+) {
+    ROOM_NOT_FOUND(10001, HttpStatus.NOT_FOUND),
+}

--- a/src/main/kotlin/com/wafflestudio/draft/repository/RoomRepository.kt
+++ b/src/main/kotlin/com/wafflestudio/draft/repository/RoomRepository.kt
@@ -2,54 +2,37 @@ package com.wafflestudio.draft.repository
 
 import com.wafflestudio.draft.model.Room
 import com.wafflestudio.draft.model.User
-import org.springframework.stereotype.Repository
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
 import java.time.LocalDateTime
-import javax.persistence.EntityManager
 
-@Repository
-class RoomRepository(private val em: EntityManager) {
-    fun save(room: Room?) {
-        em.persist(room)
-    }
+interface RoomRepository : JpaRepository<Room?, Long?> {
 
-    fun findOne(id: Long?): Room {
-        return em.find(Room::class.java, id)
-    }
+    @Query("SELECT r FROM Room r " +
+            "INNER JOIN r.court c " +
+            "INNER JOIN c.region reg " +
+            "WHERE r.name LIKE %:name% " +
+            "AND (COALESCE(:start_time, null) is null or r.startTime >= :start_time) " +
+            "AND (COALESCE(:end_time, null) is null or r.endTime <= :end_time) " +
+            "AND reg.id = :region_id ")
+    fun findByNameAndOptionalRegionIdAndOptionalStartTimeAndOptionalEndTime(
+            @Param("name") name: String?,
+            @Param("region_id") regionId: Long?,
+            @Param("start_time") startTime: LocalDateTime?,
+            @Param("end_time") endTime: LocalDateTime?
+    ): List<Room>?
 
-    fun findRooms(name: String?, regionId: Long?, startTime: LocalDateTime?, endTime: LocalDateTime?): List<Room>? {
-        return if (regionId == null) {
-            em.createQuery("SELECT r FROM Room r " +
-                    "WHERE r.name LIKE '%'||:name||'%' " +
-                    "AND (COALESCE(:start_time, null) is null or r.startTime >= :start_time) " +
-                    "AND (COALESCE(:end_time, null) is null or r.endTime <= :end_time) "
-                    , Room::class.java)
-                    .setParameter("name", name)
-                    .setParameter("start_time", startTime)
-                    .setParameter("end_time", endTime)
-                    .resultList
-        } else {
-            em.createQuery("SELECT r FROM Room r " +
-                    "INNER JOIN r.court c " +
-                    "INNER JOIN c.region reg " +
-                    "WHERE r.name LIKE '%'||:name||'%' " +
-                    "AND (COALESCE(:start_time, null) is null or r.startTime >= :start_time) " +
-                    "AND (COALESCE(:end_time, null) is null or r.endTime <= :end_time) " +
-                    "AND reg.id = :region_id "
-                    , Room::class.java)
-                    .setParameter("name", name)
-                    .setParameter("start_time", startTime)
-                    .setParameter("end_time", endTime)
-                    .setParameter("region_id", regionId)
-                    .resultList
-        }
-    }
+    @Query("SELECT r FROM Room r " +
+            "WHERE r.name LIKE %:name% " +
+            "AND (COALESCE(:start_time, null) is null or r.startTime >= :start_time) " +
+            "AND (COALESCE(:end_time, null) is null or r.endTime <= :end_time)")
+    fun findByNameAndOptionalStartTimeAndOptionalEndTime(
+            @Param("name") name: String?,
+            @Param("start_time") startTime: LocalDateTime?,
+            @Param("end_time") endTime: LocalDateTime?
+    ): List<Room>?
 
-    fun findRoomsByUser(user: User?): MutableList<Room>? {
-        return em.createQuery("SELECT r FROM Participant p " +
-                "INNER JOIN p.room r " +
-                "WHERE p.user = :user"
-                , Room::class.java)
-                .setParameter("user", user)
-                .resultList
-    }
+    @Query("SELECT r FROM Participant p INNER JOIN p.room r WHERE p.user = :participatingUser")
+    fun findByParticipatingUser(participatingUser: User?): List<Room>?
 }

--- a/src/main/kotlin/com/wafflestudio/draft/service/RoomService.kt
+++ b/src/main/kotlin/com/wafflestudio/draft/service/RoomService.kt
@@ -1,8 +1,8 @@
 package com.wafflestudio.draft.service
 
-import com.wafflestudio.draft.dto.response.RoomResponse
 import com.wafflestudio.draft.model.Room
 import com.wafflestudio.draft.model.User
+import com.wafflestudio.draft.error.RoomNotFoundException
 import com.wafflestudio.draft.repository.RoomRepository
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -10,7 +10,7 @@ import java.time.LocalDateTime
 
 @Service
 @Transactional(readOnly = true)
-class RoomService(private val roomRepository: RoomRepository, private val participantService: ParticipantService) {
+class RoomService(private val roomRepository: RoomRepository) {
     @Transactional
     fun save(room: Room): Long? {
         roomRepository.save(room)
@@ -18,15 +18,19 @@ class RoomService(private val roomRepository: RoomRepository, private val partic
     }
 
     fun findRooms(name: String?, regionId: Long?, startTime: LocalDateTime?, endTime: LocalDateTime?): List<Room>? {
-        return roomRepository.findRooms(name, regionId, startTime, endTime)
+        if (regionId == null) {
+            return roomRepository.findByNameAndOptionalStartTimeAndOptionalEndTime(name, startTime, endTime)
+        }
+        return roomRepository.findByNameAndOptionalRegionIdAndOptionalStartTimeAndOptionalEndTime(
+                name, regionId, startTime, endTime
+        )
     }
 
-    fun findOne(roomId: Long): Room? {
-        return roomRepository.findOne(roomId)
+    fun findOne(roomId: Long): Room {
+        return roomRepository.findById(roomId).orElseThrow(::RoomNotFoundException)!!
     }
-
 
     fun findRoomsByUser(user: User): List<Room>? {
-        return roomRepository.findRoomsByUser(user)
+        return roomRepository.findByParticipatingUser(user)
     }
 }

--- a/src/test/java/com/wafflestudio/draft/api/RoomApiControllerTest.java
+++ b/src/test/java/com/wafflestudio/draft/api/RoomApiControllerTest.java
@@ -41,6 +41,9 @@ public class RoomApiControllerTest {
                 .andExpect(jsonPath("$['name']", is("TEST_ROOM_1")))
                 .andExpect(jsonPath("$['participants']", hasSize(1)))
                 .andExpect(jsonPath("$['participants'][0]['id']", is(1)));
+
+        this.mockMvc.perform(get("/api/v1/room/{roomId}", 100).contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isNotFound());
     }
 
     @Test

--- a/src/test/java/com/wafflestudio/draft/service/RoomServiceTest.java
+++ b/src/test/java/com/wafflestudio/draft/service/RoomServiceTest.java
@@ -56,6 +56,6 @@ class RoomServiceTest {
         Long savedId = roomService.save(room);
 
         // then
-        assertEquals(room, roomRepository.findOne(savedId));
+        assertEquals(room, roomRepository.findById(savedId).get());
     }
 }


### PR DESCRIPTION
related issues: https://trello.com/c/rarb1Hrb

# Major Changes
## 1. RoomRepository가 JpaRepository를 사용하도록 변경
- optional paramter를 더 똑똑히 처리할 방법이 있을지 찾아보았지만 딱히 찾지 못함. 이 이상의 뭔가가 별로 없는 듯?
  - https://stackoverflow.com/questions/32728843/spring-data-optional-parameter-in-query-method

## 2. 앞으로 사용할 수 있는 일관된 error handling 처리 방식 도입
- Exception, ErrorType, ErrorResponse를 직접 정의. 매번 controller에서 복잡하게 error handling 하지 않고, service 등의 layer에서 error를 바로 편하게 일으킬 수 있음. 해당 파일을 문서처럼 예쁘게 정의하는 데에 사용할 것.
- RestControllerAdivice를 이용해 직접 정의한 DraftException을 잡아주는 ErrorHandler 구현
