### PR TITLE
dockerize draft-server

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM openjdk:11-jdk-slim
+WORKDIR /app
+COPY . /app
+RUN ./gradlew bootJar
+EXPOSE 8080
+CMD java -jar -Dspring.profiles.active=prod build/libs/draft-0.0.1.jar

--- a/draft-server.iml
+++ b/draft-server.iml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <module type="JAVA_MODULE" version="4">
-  <component name="NewModuleRootManager" LANGUAGE_LEVEL="JDK_1_8" inherit-compiler-output="true">
+  <component name="NewModuleRootManager" LANGUAGE_LEVEL="JDK_11" inherit-compiler-output="true">
     <exclude-output />
     <content url="file://$MODULE_DIR$" />
     <orderEntry type="jdk" jdkName="11" jdkType="JavaSDK" />

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -1,0 +1,10 @@
+spring:
+  profiles: local
+  datasource:
+    jdbc-url: jdbc:postgresql://localhost:5432/draft?serverTimezone=UTC
+    username: draft
+    password: draft-pw
+    initialization-mode: always
+    data:
+      - classpath:emd1.sql
+      - classpath:emd2.sql

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -1,0 +1,10 @@
+spring:
+  profiles: prod
+  datasource:
+    jdbc-url: jdbc:postgresql://draft-db.caxwrw8c4qqq.ap-northeast-2.rds.amazonaws.com/draft?serverTimezone=UTC
+    username: postgres
+    password: coffee-urban
+    initialization-mode: always
+    data:
+      - classpath:emd1.sql
+      - classpath:emd2.sql

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,6 +1,6 @@
 spring:
   profiles:
-    active: prod
+    active: local
   jpa:
     hibernate:
       ddl-auto: create

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,12 +1,6 @@
 spring:
-  datasource:
-    jdbc-url: jdbc:postgresql://localhost:5432/draft?serverTimezone=UTC
-    username: draft
-    password: draft-pw
-    initialization-mode: always
-    data:
-      - classpath:emd1.sql
-      - classpath:emd2.sql
+  profiles:
+    active: prod
   jpa:
     hibernate:
       ddl-auto: create


### PR DESCRIPTION
related issues: https://trello.com/c/kChDyTbi

# Major Changes
## 1. dockerize draft-server
- 자동 배포를 위한 첫 단계: prod 환경 docker image화하기
- prod, local 환경 분리. local이 default.
- prod 환경의 DB 정보에 대해 AWS Secrets Manager 등 안전한 방식을 추후 적용할 필요가 있음. (일단 현재는 Security Group을 믿고... 하드코딩)
